### PR TITLE
Remove command using commands.json as reference

### DIFF
--- a/clir/utils/objects.py
+++ b/clir/utils/objects.py
@@ -136,6 +136,7 @@ class CommandTable:
         json_file_path = os.path.join(os.path.expanduser('~'), '.clir/commands.json')
 
         uid = self.get_command_uid()
+        all_commands = _get_commands()
         
         del_command = ""
         for command in self.commands:
@@ -143,11 +144,11 @@ class CommandTable:
                 del_command = command
 
         if uid:
-            self.commands.pop(str(del_command))
+            all_commands.pop(str(del_command))
 
             # Write updated data to JSON file
             with open(json_file_path, 'w') as json_file:
-                json.dump(self.commands, json_file)
+                json.dump(all_commands, json_file)
 
             print(f'Command removed successfuly')
 


### PR DESCRIPTION
This PR solves a bug when removing a command using the --grep flag.

Problem: using the commands shown in the table as reference for the new list of commands after the deletion was done.

Solution: use the complete list of commands in commands.json as the new reference.