### PR TITLE
Add/allow arguments in commands

### DIFF
--- a/clir/utils/objects.py
+++ b/clir/utils/objects.py
@@ -262,12 +262,20 @@ def _get_user_input(arg):
 def _replace_arguments(command):
     # Use regex to find all arguments with underscores
     matches = re.findall(r'_\w+', command)
+
+    print(f"Found {matches} arguments")
     
     # Prompt the user for values for each argument
     replacements = {arg: _get_user_input(arg) for arg in matches}
+
+    print(f"Replacing arguments with values: {replacements}")
     
+    command_list = command.split(" ")
+
     # Replace arguments in the command
     for arg, value in replacements.items():
-        command = command.replace(arg, value)
+        for indx,term in enumerate(command_list):
+            if arg == term:
+                command_list[indx] = value
     
-    return command
+    return " ".join(command_list)

--- a/clir/utils/objects.py
+++ b/clir/utils/objects.py
@@ -98,6 +98,7 @@ class CommandTable:
             if current_commands[c]["uid"] == uid:
                 command = c
         
+        command = _replace_arguments(command)
         if uid:
             print(f'Running command: {command}')
             os.system(command)
@@ -254,3 +255,19 @@ def _get_commands(tag: str = "", grep: str = ""):
     sorted_commands = dict(sorted(current_commands.items(), key=lambda item: item[1]["tag"]))
 
     return sorted_commands
+
+def _get_user_input(arg):
+    return input(f"Enter value for '{arg}': ")
+
+def _replace_arguments(command):
+    # Use regex to find all arguments with underscores
+    matches = re.findall(r'_\w+', command)
+    
+    # Prompt the user for values for each argument
+    replacements = {arg: _get_user_input(arg) for arg in matches}
+    
+    # Replace arguments in the command
+    for arg, value in replacements.items():
+        command = command.replace(arg, value)
+    
+    return command

--- a/clir/utils/objects.py
+++ b/clir/utils/objects.py
@@ -5,6 +5,7 @@ import uuid
 import platform
 import subprocess
 from rich import box
+from rich import print
 from rich.console import Console
 from rich.table import Table
 from rich.prompt import Prompt
@@ -99,8 +100,8 @@ class CommandTable:
                 command = c
         
         command = _replace_arguments(command)
-        if uid:
-            print(f'Running command: {command}')
+        if uid and command:
+            print(f'[bold green]Running command:[/bold green] {command}')
             os.system(command)
     
     def copy_command(self):
@@ -263,13 +264,15 @@ def _replace_arguments(command):
     # Use regex to find all arguments with underscores
     matches = re.findall(r'_\w+', command)
 
-    print(f"Found {matches} arguments")
+    # Check that all arguments are unique
+    if len(matches) != len(set(matches)):
+        print("[bold red]Make sure that all arguments are unique[/bold red]")
+        return None
     
     # Prompt the user for values for each argument
     replacements = {arg: _get_user_input(arg) for arg in matches}
-
-    print(f"Replacing arguments with values: {replacements}")
     
+    # Split the command into a list
     command_list = command.split(" ")
 
     # Replace arguments in the command

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "clir"
-version = "0.4.3"
+version = "0.5.0"
 description = "A clear and fast way to store and recover your commands"
 authors = ["Elkin Aguas <elkinaguas@gmail.com>"]
 license = "MIT License"


### PR DESCRIPTION
This pull request adds support for arguments in commands.

To add an argument to a command, just add un underscore in front of the argument. When you run the command with clir, it will ask you to input the commands you specified.

Example:
commad : `echo _text ; echo _text2 ; echo text3`

Prompt after running the command with clir:
```bash
Enter value for '_text': hola
Enter value for '_text2': mundo
Running command: echo hola ; echo mundo ; echo text3
hola
mundo
text3
```