### PR TITLE
Harden clipboard execution and import error handling

### DIFF
--- a/clir/command.py
+++ b/clir/command.py
@@ -4,15 +4,14 @@ import json
 import uuid
 import platform
 import subprocess
-from datetime import datetime
 from rich import box
 from rich import print
 from rich.console import Console
 from rich.table import Table
 from rich.prompt import Prompt
-from clir.utils.config import verify_xclip_installation
-from clir.utils.core import get_commands, replace_arguments, transform_commands_to_json, remove_tag_if_no_commands
-from clir.utils.db import insert_command_db, get_commands_db, remove_command_db, verify_command_id_exists, verify_command_id_tag_relation_exists, modify_command_db, get_tag_id_from_command_id, get_tags_db
+from clir.utils.config import verify_clipboard_tool_installation
+from clir.utils.core import replace_arguments, transform_commands_to_json, remove_tag_if_no_commands
+from clir.utils.db import insert_command_db, get_commands_db, remove_command_db, verify_command_id_exists, verify_command_id_tag_relation_exists, modify_command_db, get_tags_db
 
 class Command:
     def __init__(self, command: str = "", description: str = "", tag: str = ""):
@@ -101,8 +100,15 @@ class CommandTable:
         command = replace_arguments(command)
         if uid and command:
             print(f'[bold green]Running command:[/bold green] {command}')
-            os.system(command)
-            subprocess.Popen(['bash', '-ic', 'set -o history; history -s "$1"', '_', command])
+            subprocess.run(command, shell=True, check=False)
+            try:
+                subprocess.Popen(
+                    ['bash', '-ic', 'set -o history; history -s "$1"', '_', command],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            except OSError:
+                pass
     
     def copy_command(self):
         current_commands = self.commands
@@ -118,15 +124,28 @@ class CommandTable:
             print(f'Copying command: {command}')
             if platform.system() == "Darwin":
                 # Verify that pbcopy is installed
-                if verify_xclip_installation(package = "pbcopy"):
-                    os.system(f'printf "{command}" | pbcopy')
+                if verify_clipboard_tool_installation(package = "pbcopy"):
+                    try:
+                        subprocess.run(["pbcopy"], input=command, text=True, check=True)
+                    except (subprocess.CalledProcessError, OSError):
+                        print("pbcopy failed to copy the command. Please verify clipboard access and try again")
+                        return
                 else:
                     print("pbcopy is not installed, this command needs pbcopy to work properly")
                     return
             elif platform.system() == "Linux" or platform.system().startswith("CYGWIN"):
                 # Verify that xclip is installed
-                if verify_xclip_installation(package = "xclip"):
-                    os.system(f'echo -n "{command}" | xclip -selection clipboard')
+                if verify_clipboard_tool_installation(package = "xclip"):
+                    try:
+                        subprocess.run(
+                            ["xclip", "-selection", "clipboard"],
+                            input=command,
+                            text=True,
+                            check=True,
+                        )
+                    except (subprocess.CalledProcessError, OSError):
+                        print("xclip failed to copy the command. Please verify clipboard access and try again")
+                        return
                 else:
                     print("xclip is not installed, this command needs xclip to work properly")
                     return
@@ -157,7 +176,7 @@ class CommandTable:
             with open("commands.json", "w") as commands_file:
                 json.dump(self.commands, commands_file)
             print(f"[bold green]Commands exported succesfully[/bold green] to {os.getcwd()}/commands.json")
-        except:
+        except OSError:
             print("[bold red]Commands could not be exported[/bold red]")
             raise
     
@@ -172,8 +191,10 @@ class CommandTable:
                     with open(import_file_path, 'r') as import_file:
                         print(f"Importing commands from {import_file_path}...")
                         import_commands =  json.load(import_file)
-                except Exception as e:
-                    raise Exception(f"Un error ocurred while reading the file '{import_file_path}'")
+                except (OSError, json.JSONDecodeError) as exc:
+                    raise ValueError(
+                        f"An error occurred while reading the file '{import_file_path}': {exc}"
+                    ) from exc
             else:
                 raise FileNotFoundError(f"File '{import_file_path}' could not be found")
 

--- a/clir/utils/config.py
+++ b/clir/utils/config.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import subprocess
 from pathlib import Path
 from clir.utils.db import create_database
 from clir.utils.core import get_commands
@@ -101,18 +100,8 @@ def init_config():
         return
     
 
-def verify_xclip_installation(package: str = ""):
-    if package == "xclip":
-        try:
-            subprocess.run(["xclip", "-version"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            return True
-        except:
-            return False
-    if package == "pbcopy":
-        try:
-            subprocess.run(["which", "pbcopy"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            return True
-        except:
-            return False
-    
-    return "No package specified"
+def verify_clipboard_tool_installation(package: str = ""):
+    if package in {"xclip", "pbcopy"}:
+        return shutil.which(package) is not None
+
+    return False

--- a/tests/10-import_export_edges.py
+++ b/tests/10-import_export_edges.py
@@ -22,7 +22,7 @@ def test_import_commands_raises_for_invalid_json(tmp_path):
     invalid_file = tmp_path / "broken.json"
     invalid_file.write_text("{ not-json", encoding="utf-8")
 
-    with pytest.raises(Exception, match="Un error ocurred while reading the file"):
+    with pytest.raises(ValueError, match="An error occurred while reading the file"):
         table.import_commands(str(invalid_file))
 
 

--- a/tests/12-config_utils.py
+++ b/tests/12-config_utils.py
@@ -43,35 +43,29 @@ def test_init_config_returns_when_setup_cannot_be_completed(monkeypatch):
     ]
 
 
-def test_verify_xclip_installation_xclip_true(monkeypatch):
-    monkeypatch.setattr(config_module.subprocess, "run", lambda *args, **kwargs: None)
+def test_verify_clipboard_tool_installation_xclip_true(monkeypatch):
+    monkeypatch.setattr(config_module.shutil, "which", lambda package: f"/usr/bin/{package}")
 
-    assert config_module.verify_xclip_installation("xclip") is True
-
-
-def test_verify_xclip_installation_xclip_false_on_error(monkeypatch):
-    def fail(*args, **kwargs):
-        raise RuntimeError("missing")
-
-    monkeypatch.setattr(config_module.subprocess, "run", fail)
-
-    assert config_module.verify_xclip_installation("xclip") is False
+    assert config_module.verify_clipboard_tool_installation("xclip") is True
 
 
-def test_verify_xclip_installation_pbcopy_true(monkeypatch):
-    monkeypatch.setattr(config_module.subprocess, "run", lambda *args, **kwargs: None)
+def test_verify_clipboard_tool_installation_xclip_false_on_error(monkeypatch):
+    monkeypatch.setattr(config_module.shutil, "which", lambda package: None)
 
-    assert config_module.verify_xclip_installation("pbcopy") is True
-
-
-def test_verify_xclip_installation_pbcopy_false_on_error(monkeypatch):
-    def fail(*args, **kwargs):
-        raise RuntimeError("missing")
-
-    monkeypatch.setattr(config_module.subprocess, "run", fail)
-
-    assert config_module.verify_xclip_installation("pbcopy") is False
+    assert config_module.verify_clipboard_tool_installation("xclip") is False
 
 
-def test_verify_xclip_installation_without_package_returns_message():
-    assert config_module.verify_xclip_installation() == "No package specified"
+def test_verify_clipboard_tool_installation_pbcopy_true(monkeypatch):
+    monkeypatch.setattr(config_module.shutil, "which", lambda package: f"/usr/bin/{package}")
+
+    assert config_module.verify_clipboard_tool_installation("pbcopy") is True
+
+
+def test_verify_clipboard_tool_installation_pbcopy_false_on_error(monkeypatch):
+    monkeypatch.setattr(config_module.shutil, "which", lambda package: None)
+
+    assert config_module.verify_clipboard_tool_installation("pbcopy") is False
+
+
+def test_verify_clipboard_tool_installation_without_package_returns_false():
+    assert config_module.verify_clipboard_tool_installation() is False

--- a/tests/9-command_branches.py
+++ b/tests/9-command_branches.py
@@ -1,3 +1,5 @@
+import subprocess
+
 from clir.command import Command
 from clir.command import CommandTable
 import clir.command as command_module
@@ -41,12 +43,16 @@ def test_copy_command_uses_pbcopy_on_darwin(monkeypatch):
     calls = []
     monkeypatch.setattr(CommandTable, "get_command_uid", lambda self: "uid-1")
     monkeypatch.setattr(command_module.platform, "system", lambda: "Darwin")
-    monkeypatch.setattr(command_module, "verify_xclip_installation", lambda package: True)
-    monkeypatch.setattr(command_module.os, "system", lambda cmd: calls.append(cmd))
+    monkeypatch.setattr(command_module, "verify_clipboard_tool_installation", lambda package: True)
+    monkeypatch.setattr(
+        command_module.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
 
     table.copy_command()
 
-    assert calls == ['printf "echo hello" | pbcopy']
+    assert calls == [((['pbcopy'],), {'input': 'echo hello', 'text': True, 'check': True})]
 
 
 def test_copy_command_shows_missing_tool_on_linux(monkeypatch):
@@ -56,8 +62,12 @@ def test_copy_command_shows_missing_tool_on_linux(monkeypatch):
     calls = []
     monkeypatch.setattr(CommandTable, "get_command_uid", lambda self: "uid-1")
     monkeypatch.setattr(command_module.platform, "system", lambda: "Linux")
-    monkeypatch.setattr(command_module, "verify_xclip_installation", lambda package: False)
-    monkeypatch.setattr(command_module.os, "system", lambda cmd: calls.append(cmd))
+    monkeypatch.setattr(command_module, "verify_clipboard_tool_installation", lambda package: False)
+    monkeypatch.setattr(
+        command_module.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
 
     table.copy_command()
 
@@ -71,7 +81,11 @@ def test_copy_command_handles_unsupported_os(monkeypatch):
     calls = []
     monkeypatch.setattr(CommandTable, "get_command_uid", lambda self: "uid-1")
     monkeypatch.setattr(command_module.platform, "system", lambda: "Windows")
-    monkeypatch.setattr(command_module.os, "system", lambda cmd: calls.append(cmd))
+    monkeypatch.setattr(
+        command_module.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
 
     table.copy_command()
 
@@ -87,17 +101,50 @@ def test_run_command_executes_replaced_command(monkeypatch):
 
     monkeypatch.setattr(CommandTable, "get_command_uid", lambda self: "uid-1")
     monkeypatch.setattr(command_module, "replace_arguments", lambda cmd: "echo alice")
-    monkeypatch.setattr(command_module.os, "system", lambda cmd: executed.append(cmd))
+    monkeypatch.setattr(
+        command_module.subprocess,
+        "run",
+        lambda *args, **kwargs: executed.append((args, kwargs)),
+    )
     monkeypatch.setattr(
         command_module.subprocess,
         "Popen",
-        lambda args: history_calls.append(args),
+        lambda *args, **kwargs: history_calls.append((args, kwargs)),
     )
 
     table.run_command()
 
-    assert executed == ["echo alice"]
-    assert history_calls == [["bash", "-ic", 'set -o history; history -s "$1"', "_", "echo alice"]]
+    assert executed == [(("echo alice",), {"shell": True, "check": False})]
+    assert history_calls == [
+        (
+            (["bash", "-ic", 'set -o history; history -s "$1"', "_", "echo alice"],),
+            {"stdout": command_module.subprocess.DEVNULL, "stderr": command_module.subprocess.DEVNULL},
+        )
+    ]
+
+
+def test_run_command_ignores_history_spawn_failure(monkeypatch):
+    table = object.__new__(CommandTable)
+    table.commands = {"echo @name": {"uid": "uid-1"}}
+
+    executed = []
+
+    monkeypatch.setattr(CommandTable, "get_command_uid", lambda self: "uid-1")
+    monkeypatch.setattr(command_module, "replace_arguments", lambda cmd: "echo alice")
+    monkeypatch.setattr(
+        command_module.subprocess,
+        "run",
+        lambda *args, **kwargs: executed.append((args, kwargs)),
+    )
+
+    def fail_history(*args, **kwargs):
+        raise OSError("bash unavailable")
+
+    monkeypatch.setattr(command_module.subprocess, "Popen", fail_history)
+
+    table.run_command()
+
+    assert executed == [(("echo alice",), {"shell": True, "check": False})]
 
 
 def test_command_str_and_repr_include_fields():
@@ -124,8 +171,12 @@ def test_copy_command_shows_missing_pbcopy_on_darwin(monkeypatch):
     calls = []
     monkeypatch.setattr(CommandTable, "get_command_uid", lambda self: "uid-1")
     monkeypatch.setattr(command_module.platform, "system", lambda: "Darwin")
-    monkeypatch.setattr(command_module, "verify_xclip_installation", lambda package: False)
-    monkeypatch.setattr(command_module.os, "system", lambda cmd: calls.append(cmd))
+    monkeypatch.setattr(command_module, "verify_clipboard_tool_installation", lambda package: False)
+    monkeypatch.setattr(
+        command_module.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
 
     table.copy_command()
 
@@ -139,12 +190,64 @@ def test_copy_command_linux_uses_xclip_when_available(monkeypatch):
     calls = []
     monkeypatch.setattr(CommandTable, "get_command_uid", lambda self: "uid-1")
     monkeypatch.setattr(command_module.platform, "system", lambda: "Linux")
-    monkeypatch.setattr(command_module, "verify_xclip_installation", lambda package: True)
-    monkeypatch.setattr(command_module.os, "system", lambda cmd: calls.append(cmd))
+    monkeypatch.setattr(command_module, "verify_clipboard_tool_installation", lambda package: True)
+    monkeypatch.setattr(
+        command_module.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
 
     table.copy_command()
 
-    assert calls == ['echo -n "echo hello" | xclip -selection clipboard']
+    assert calls == [
+        ((['xclip', '-selection', 'clipboard'],), {'input': 'echo hello', 'text': True, 'check': True})
+    ]
+
+
+def test_copy_command_shows_clipboard_failure_on_linux(monkeypatch):
+    table = object.__new__(CommandTable)
+    table.commands = {"echo hello": {"uid": "uid-1"}}
+
+    messages = []
+
+    def fail(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, ["xclip", "-selection", "clipboard"])
+
+    monkeypatch.setattr(CommandTable, "get_command_uid", lambda self: "uid-1")
+    monkeypatch.setattr(command_module.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(command_module, "verify_clipboard_tool_installation", lambda package: True)
+    monkeypatch.setattr(command_module.subprocess, "run", fail)
+    monkeypatch.setattr(command_module, "print", lambda *args, **kwargs: messages.append(args[0]))
+
+    table.copy_command()
+
+    assert messages == [
+        "Copying command: echo hello",
+        "xclip failed to copy the command. Please verify clipboard access and try again",
+    ]
+
+
+def test_copy_command_shows_clipboard_failure_on_darwin(monkeypatch):
+    table = object.__new__(CommandTable)
+    table.commands = {"echo hello": {"uid": "uid-1"}}
+
+    messages = []
+
+    def fail(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, ["pbcopy"])
+
+    monkeypatch.setattr(CommandTable, "get_command_uid", lambda self: "uid-1")
+    monkeypatch.setattr(command_module.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(command_module, "verify_clipboard_tool_installation", lambda package: True)
+    monkeypatch.setattr(command_module.subprocess, "run", fail)
+    monkeypatch.setattr(command_module, "print", lambda *args, **kwargs: messages.append(args[0]))
+
+    table.copy_command()
+
+    assert messages == [
+        "Copying command: echo hello",
+        "pbcopy failed to copy the command. Please verify clipboard access and try again",
+    ]
 
 
 def test_show_tags_renders_unique_tags(monkeypatch):


### PR DESCRIPTION
## Summary
- harden clipboard copy flows by using subprocess stdin instead of shell-interpolated commands and add graceful runtime failure handling
- preserve shell-based command execution compatibility while making bash history updates best-effort and non-fatal
- tighten touched error handling and update tests for clipboard, config, and import edge cases

## Validation
- poetry run pytest -v -s tests/9-command_branches.py::test_copy_command_uses_pbcopy_on_darwin
- poetry run pytest -v -s tests/9-command_branches.py tests/12-config_utils.py
- poetry run pytest -v -s tests/10-import_export_edges.py
- poetry run pytest -v -s tests/9-command_branches.py::test_copy_command_shows_clipboard_failure_on_linux tests/12-config_utils.py
- poetry run pytest -v -s tests/9-command_branches.py::test_run_command_ignores_history_spawn_failure tests/9-command_branches.py::test_run_command_executes_replaced_command
- poetry run pytest -v -s tests/1-init_clir.py tests/2-add_command.py tests/3-copy_command.py tests/4-run_command.py tests/5-remove_command.py tests/6-list_command.py tests/7-import_export_command.py