### PR TITLE
Refactor CLI setup and DB helper flows

### DIFF
--- a/clir/cli.py
+++ b/clir/cli.py
@@ -1,14 +1,25 @@
 import rich_click as click
-import os
-import subprocess
 from rich.prompt import Prompt
+
 from clir.command import Command
 from clir.command import CommandTable
 from clir.utils.config import init_config
 
+
 @click.group()
 def cli():
     pass
+
+
+def _get_command_table(tag: str = "", grep: str = "") -> CommandTable:
+    init_config()
+    return CommandTable(tag=tag, grep=grep)
+
+
+def _prompt_import_file(file_path: str = "") -> str:
+    while not file_path:
+        file_path = str(Prompt.ask("Insert import file path"))
+    return file_path
 
 
 
@@ -18,68 +29,49 @@ def cli():
 @click.option('-t', '--tag', help="Tag to be associated with the command", prompt=True)
 def new(command, description, tag):
     init_config()
-    new_command = Command(command = command, description = description, tag = tag)
+    new_command = Command(command=command, description=description, tag=tag)
     new_command.save_command()
 
 @cli.command(help="Remove command(s) 👋. In the prompt use 1,3-5 or all")
 @click.option('-t', '--tag', help="Search by tag")
 @click.option('-g', '--grep', help="Search by grep")
 def rm(tag: str = "", grep: str = ""):
-    init_config()
-    table = CommandTable(tag=tag, grep=grep)
-    table.remove_command()
+    _get_command_table(tag=tag, grep=grep).remove_command()
 
 @cli.command(help="List commands 📃")
 @click.option('-t', '--tag', help="Search by tag")
 @click.option('-g', '--grep', help="Search by grep")
 def ls(tag: str = "", grep: str = ""):
-    init_config()    
-    table = CommandTable(tag=tag, grep=grep)
-    table.show_table()
+    _get_command_table(tag=tag, grep=grep).show_table()
 
 @cli.command(help="Run command 🚀")
 @click.option('-t', '--tag', help="Search by tag")
 @click.option('-g', '--grep', help="Search by grep")
 def run(tag: str = "", grep: str = ""):
-    init_config()
-    table = CommandTable(tag=tag, grep=grep)
-    table.run_command()
+    _get_command_table(tag=tag, grep=grep).run_command()
 
 @cli.command(help="Copy command to clipboard 📋")
 @click.option('-t', '--tag', help="Search by tag")
 @click.option('-g', '--grep', help="Search by grep")
 def cp(tag: str = "", grep: str = ""):
-    init_config()
-    table = CommandTable(tag=tag, grep=grep)
-    table.copy_command()
+    _get_command_table(tag=tag, grep=grep).copy_command()
 
 @cli.command(help="Show tags 🏷️")
 @click.option('-g', '--grep', help="Search by grep")
 def tags(grep: str = ""):
-    init_config()
-    table = CommandTable(grep=grep)
-    table.show_tags()
+    _get_command_table(grep=grep).show_tags()
 
 @cli.command(help="Import commands from file 🤓")
 @click.option('-f', '--file', help="Search by grep")
 def imports(file: str = ""):
     init_config()
-    if file:
-        table = CommandTable()
-        table.import_commands(import_file_path = file)
-    else:
-        while not file:
-            file = str(Prompt.ask("Insert import file path"))
-        table = CommandTable()
-        table.import_commands(import_file_path = file)
+    CommandTable().import_commands(import_file_path=_prompt_import_file(file))
 
 @cli.command(help="Export commands to file 📤")
 @click.option('-t', '--tag', help="Search by tag")
 @click.option('-g', '--grep', help="Search by grep")
 def export(tag: str = "", grep: str = ""):
-    init_config()
-    table = CommandTable(tag=tag, grep=grep)
-    table.export_commands()
+    _get_command_table(tag=tag, grep=grep).export_commands()
 
 @cli.command(help="Settings ⚙️")
 def settings():

--- a/clir/command.py
+++ b/clir/command.py
@@ -1,17 +1,27 @@
 import os
-import re
 import json
 import uuid
 import platform
+import re
 import subprocess
+
 from rich import box
 from rich import print
 from rich.console import Console
-from rich.table import Table
 from rich.prompt import Prompt
+from rich.table import Table
+
 from clir.utils.config import verify_clipboard_tool_installation
-from clir.utils.core import replace_arguments, transform_commands_to_json, remove_tag_if_no_commands
-from clir.utils.db import insert_command_db, get_commands_db, remove_command_db, verify_command_id_exists, verify_command_id_tag_relation_exists, modify_command_db, get_tags_db
+from clir.utils.core import remove_tag_if_no_commands, replace_arguments, transform_commands_to_json
+from clir.utils.db import (
+    get_commands_db,
+    get_tags_db,
+    insert_command_db,
+    modify_command_db,
+    remove_command_db,
+    verify_command_id_exists,
+    verify_command_id_tag_relation_exists,
+)
 
 class Command:
     def __init__(self, command: str = "", description: str = "", tag: str = ""):
@@ -27,8 +37,6 @@ class Command:
         return f"{self.command} {self.description} {self.tag}"
 
     def save_command(self):
-        current_commands = get_commands_db()
-
         command = self.command
         desc = self.description
         tag = self.tag
@@ -53,6 +61,13 @@ class CommandTable:
 
     def __repr__(self):
         return f"{self.command} {self.description} {self.tag}"
+
+    def _get_selected_command(self, uid: str) -> str:
+        for command, data in self.commands.items():
+            if data["uid"] == uid:
+                return command
+
+        return ""
 
     def show_table(self):
 
@@ -80,7 +95,7 @@ class CommandTable:
                 
             split_command.append(local_command)
             
-            display_command = " \ \n".join(split_command)
+            display_command = " \\ \n".join(split_command)
             table.add_row(str(indx+1), display_command, split_description, commands[command]["tag"])
 
         console = Console()
@@ -88,16 +103,11 @@ class CommandTable:
         print(f"Showing {str(len(commands))} commands")
     
     def run_command(self):
-        current_commands = self.commands
-
         uid = self.get_command_uid()
-        
-        command = ""
-        for c in current_commands:
-            if current_commands[c]["uid"] == uid:
-                command = c
-        
+
+        command = self._get_selected_command(uid)
         command = replace_arguments(command)
+
         if uid and command:
             print(f'[bold green]Running command:[/bold green] {command}')
             subprocess.run(command, shell=True, check=False)
@@ -111,15 +121,10 @@ class CommandTable:
                 pass
     
     def copy_command(self):
-        current_commands = self.commands
-
         uid = self.get_command_uid()
-        
-        command = ""
-        for c in current_commands:
-            if current_commands[c]["uid"] == uid:
-                command = c
-        
+
+        command = self._get_selected_command(uid)
+
         if uid:
             print(f'Copying command: {command}')
             if platform.system() == "Darwin":

--- a/clir/utils/db.py
+++ b/clir/utils/db.py
@@ -1,10 +1,9 @@
+import datetime
+import importlib.resources
 import sqlite3
 import uuid
-import base64
+from contextlib import contextmanager
 from pathlib import Path
-import datetime
-import shutil
-import importlib.resources
 
 # Specify the directory and file name
 schema_directory = "clir/config/db/"
@@ -16,92 +15,100 @@ db_user_version = 1
 env_path = Path('~').expanduser() / Path(".clir")
 db_file = Path(env_path) / db_file_name
 
+
+def _timestamp_now() -> str:
+    return datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+
+
+@contextmanager
+def _db_connection(database_name=None):
+    connection = sqlite3.connect(database_name or db_file)
+    try:
+        yield connection
+        connection.commit()
+    except Exception:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
+
+
+def _fetchone(query: str, params=(), database_name=None):
+    with _db_connection(database_name) as conn:
+        cursor = conn.cursor()
+        try:
+            cursor.execute(query, params)
+            return cursor.fetchone()
+        finally:
+            cursor.close()
+
+
+def _fetchall(query: str, params=(), database_name=None):
+    with _db_connection(database_name) as conn:
+        cursor = conn.cursor()
+        try:
+            cursor.execute(query, params)
+            return cursor.fetchall()
+        finally:
+            cursor.close()
+
+
+def _execute(query: str, params=(), database_name=None):
+    with _db_connection(database_name) as conn:
+        cursor = conn.cursor()
+        try:
+            cursor.execute(query, params)
+        finally:
+            cursor.close()
+
+
+def _select_ids_query(table_name: str, column_name: str, values):
+    allowed_tables = {"commands", "tags"}
+    allowed_columns = {"*", "id", "tag"}
+
+    if table_name not in allowed_tables:
+        raise ValueError(f"Unsupported table name: {table_name}")
+    if column_name not in allowed_columns:
+        raise ValueError(f"Unsupported column name: {column_name}")
+
+    placeholders = ','.join('?' for _ in values)
+    return f"SELECT {column_name} FROM {table_name} WHERE id IN ({placeholders})"
+
 def _verify_tag_exists(tag: str):
-    # Connect to the SQLite database
-    conn = sqlite3.connect(db_file)
+    tag_row = _fetchone("SELECT id FROM tags WHERE tag = ?", (tag,))
 
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
+    if not tag_row:
+        return insert_tag(tag=tag, tag_uuid=str(uuid.uuid4()))
 
-    # Check if tag exists
-    cursor.execute("SELECT * FROM tags WHERE tag = ?", (tag,))
-    tag_exists = cursor.fetchone()
-
-    if not tag_exists:
-        tag_uuid = str(uuid.uuid4())
-
-        # Insert a new tag into the database
-        insert_tag(tag = tag, tag_uuid = tag_uuid)
-    else:
-        tag_uuid = cursor.execute("SELECT id FROM tags WHERE tag = ?", (tag,))
-        tag_uuid = cursor.fetchone()[0]
-    
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
-
-    return tag_uuid
+    return tag_row[0]
 
 def _verify_command_exists(command: str):
-    # Connect to the SQLite database
-    conn = sqlite3.connect(db_file)
-
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
-
-    # Check if command exists
-    cursor.execute("SELECT * FROM commands WHERE command = ?", (command,))
-    command_exists = cursor.fetchone()
-
-    if command_exists:
-        command_uuid = cursor.execute("SELECT id FROM commands WHERE command = ?", (command,))
-    else:
-        return False
-
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
-
-    return command_uuid
+    command_row = _fetchone("SELECT id FROM commands WHERE command = ?", (command,))
+    return command_row[0] if command_row else False
 
 # Creates the DB from the schema file
-def create_database(database_name = db_file, schema_file = sql_schema_path):
-    # Connect to the SQLite database (or create it if it doesn't exist)
-    conn = sqlite3.connect(database_name)
+def create_database(database_name=None, schema_file=sql_schema_path):
+    del schema_file
 
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
-
-    # Read and execute SQL statements from the schema file
-    with importlib.resources.open_text('clir.config.db', 'schema.sql') as f:
-        schema = f.read()
-        cursor.executescript(schema)
-        
-    # Commit the changes
-    conn.commit()
-
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
+    with _db_connection(database_name) as conn:
+        cursor = conn.cursor()
+        try:
+            with importlib.resources.open_text('clir.config.db', 'schema.sql') as f:
+                cursor.executescript(f.read())
+        finally:
+            cursor.close()
 
 # Insert a new command into the database
 def insert_command_db(command: str, description: str, tag: str = "", creation_date: str = "", last_modif_date: str = ""):
-    # Connect to the SQLite database
-    conn = sqlite3.connect(db_file)
-
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
-
     command_uuid = str(uuid.uuid4())
-    tag_uuid = ""
 
     if not creation_date and not last_modif_date:
-        creation_date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+        creation_date = _timestamp_now()
         last_modif_date = creation_date
     elif creation_date and not last_modif_date:
-        last_modif_date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+        last_modif_date = _timestamp_now()
     elif not creation_date and last_modif_date:
-        creation_date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+        creation_date = _timestamp_now()
 
     tag_uuid = _verify_tag_exists(tag)
 
@@ -110,306 +117,136 @@ def insert_command_db(command: str, description: str, tag: str = "", creation_da
     if command_exists:
         modify_command_db(command, description, tag)
     else:
-        # Insert a new command into the database
-        cursor.execute("INSERT INTO commands (command, description, id, creation_date, last_modif_date) VALUES (?, ?, ?, ?, ?)", (command, description, command_uuid, creation_date, last_modif_date))
-
-        # Insert a new command into the commands_tags table
-        cursor.execute("INSERT INTO commands_tags (command_id, tag_id) VALUES (?, ?)", (command_uuid, tag_uuid))
-
-    # Commit the changes
-    conn.commit()
-
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
+        with _db_connection() as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(
+                    "INSERT INTO commands (command, description, id, creation_date, last_modif_date) VALUES (?, ?, ?, ?, ?)",
+                    (command, description, command_uuid, creation_date, last_modif_date),
+                )
+                cursor.execute(
+                    "INSERT INTO commands_tags (command_id, tag_id) VALUES (?, ?)",
+                    (command_uuid, tag_uuid),
+                )
+            finally:
+                cursor.close()
 
     return 0
 
 # Modify a command in the database
 def modify_command_db(command: str, description: str, tag: str = "", creation_date: str = "", last_modif_date: str = ""):
-    # Connect to the SQLite database
-    conn = sqlite3.connect(db_file)
-
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
-
-    command_uuid = cursor.execute("SELECT id FROM commands WHERE command = ?", (command,))
-    command_uuid = cursor.fetchone()[0]
-    tag_uuid = ""
+    command_uuid = get_command_id_from_command(command)
 
     if not last_modif_date:
-        last_modif_date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
-
-    if creation_date:
-        # Modify the command in the database
-        cursor.execute("UPDATE commands SET description = ?, creation_date = ?, last_modif_date = ? WHERE command = ?", (description, creation_date, last_modif_date, command))
-    else:
-        # Modify the command in the database
-        cursor.execute("UPDATE commands SET description = ?, last_modif_date = ? WHERE command = ?", (description, last_modif_date, command))
+        last_modif_date = _timestamp_now()
 
     tag_uuid = _verify_tag_exists(tag)
 
-    # Modify the command in the commands_tags table
-    cursor.execute("UPDATE commands_tags SET tag_id = ? WHERE command_id = ?", (tag_uuid, command_uuid))
+    with _db_connection() as conn:
+        cursor = conn.cursor()
+        try:
+            if creation_date:
+                cursor.execute(
+                    "UPDATE commands SET description = ?, creation_date = ?, last_modif_date = ? WHERE command = ?",
+                    (description, creation_date, last_modif_date, command),
+                )
+            else:
+                cursor.execute(
+                    "UPDATE commands SET description = ?, last_modif_date = ? WHERE command = ?",
+                    (description, last_modif_date, command),
+                )
 
-    # Commit the changes
-    conn.commit()
-
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
+            cursor.execute(
+                "UPDATE commands_tags SET tag_id = ? WHERE command_id = ?",
+                (tag_uuid, command_uuid),
+            )
+        finally:
+            cursor.close()
 
     return 0
 
 
 # Remove a command from the database
 def remove_command_db(uid: str):
-    # Connect to the SQLite database
-    conn = sqlite3.connect(db_file)
-
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
-
-    # Remove a command from the database
-    cursor.execute("DELETE FROM commands WHERE id = ?", (uid,))
-    cursor.execute("DELETE FROM commands_tags WHERE command_id = ?", (uid,))
-
-    # Commit the changes
-    conn.commit()
-
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
+    with _db_connection() as conn:
+        cursor = conn.cursor()
+        try:
+            cursor.execute("DELETE FROM commands_tags WHERE command_id = ?", (uid,))
+            cursor.execute("DELETE FROM commands WHERE id = ?", (uid,))
+        finally:
+            cursor.close()
 
 def verify_command_id_exists(uid: str):
-    # Connect to the SQLite database
-    conn = sqlite3.connect(db_file)
-
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
-
-    # Check if command exists
-    cursor.execute("SELECT * FROM commands WHERE id = ?", (uid,))
-    command_exists = cursor.fetchone()
-
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
-
-    return True if command_exists else False
+    return _fetchone("SELECT 1 FROM commands WHERE id = ?", (uid,)) is not None
 
 def verify_tag_id_exists(uid: str):
-    # Connect to the SQLite database
-    conn = sqlite3.connect(db_file)
-
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
-
-    # Check if tag exists
-    cursor.execute("SELECT * FROM tags WHERE id = ?", (uid,))
-    tag_exists = cursor.fetchone()
-
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
-
-    return True if tag_exists else False
+    return _fetchone("SELECT 1 FROM tags WHERE id = ?", (uid,)) is not None
 
 def verify_command_id_tag_relation_exists(command_id: str):
-    # Connect to the SQLite database
-    conn = sqlite3.connect(db_file)
-
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
-
-    # Check if command_id exists in the commands_tags table
-    cursor.execute("SELECT * FROM commands_tags WHERE command_id = ?", (command_id,))
-    command_id_exists = cursor.fetchone()
-
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
-
-    return True if command_id_exists else False
+    return _fetchone("SELECT 1 FROM commands_tags WHERE command_id = ?", (command_id,)) is not None
 
 # Get all commands from the database
 def get_commands_db(tag: str = "", grep: str = ""):
-    # Connect to the SQLite database
-    conn = sqlite3.connect(db_file)
-
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
-
-    # Get all commands from the database
     if tag:
         command_ids = get_commands_from_tag(tag)
-        query = "SELECT * FROM commands WHERE id IN ({})".format(','.join('?' for _ in command_ids))
-        cursor.execute(query, command_ids)
-    elif grep:
-        cursor.execute("SELECT * FROM commands WHERE command LIKE ? OR description LIKE ?", (f"%{grep}%", f"%{grep}%"))
-    else:
-        cursor.execute("SELECT * FROM commands")
-
-    commands = cursor.fetchall()
-
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
-
-    return commands
+        if not command_ids:
+            return []
+        query = _select_ids_query("commands", "*", command_ids)
+        return _fetchall(query, tuple(command_ids))
+    if grep:
+        return _fetchall(
+            "SELECT * FROM commands WHERE command LIKE ? OR description LIKE ?",
+            (f"%{grep}%", f"%{grep}%"),
+        )
+    return _fetchall("SELECT * FROM commands")
 
 # Get all tags from the database
 def get_tags_db(grep: str = ""):
-    # Connect to the SQLite database
-    conn = sqlite3.connect(db_file)
-
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
-
-    # Get all tags from the database
     if grep:
-        cursor.execute("SELECT * FROM tags WHERE tag LIKE ?", (f"%{grep}%",))
-    else:
-        cursor.execute("SELECT * FROM tags")
-
-    tags = cursor.fetchall()
-
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
-
-    return tags
+        return _fetchall("SELECT * FROM tags WHERE tag LIKE ?", (f"%{grep}%",))
+    return _fetchall("SELECT * FROM tags")
 
 # Insert a new tag into the database
-def insert_tag(tag: str, tag_uuid: str = str(uuid.uuid4())):
-    # Connect to the SQLite database
-    conn = sqlite3.connect(db_file)
+def insert_tag(tag: str, tag_uuid: str = None):
+    if tag_uuid is None:
+        tag_uuid = str(uuid.uuid4())
 
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
-    creation_date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+    creation_date = _timestamp_now()
     last_modif_date = creation_date
 
-    # Insert a new tag into the database
-    cursor.execute("INSERT INTO tags (tag, id, creation_date, last_modif_date) VALUES (?, ?, ?, ?)", (tag, tag_uuid, creation_date, last_modif_date))
-
-    # Commit the changes
-    conn.commit()
-
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
+    with _db_connection() as conn:
+        cursor = conn.cursor()
+        try:
+            cursor.execute(
+                "INSERT INTO tags (tag, id, creation_date, last_modif_date) VALUES (?, ?, ?, ?)",
+                (tag, tag_uuid, creation_date, last_modif_date),
+            )
+        finally:
+            cursor.close()
 
     return tag_uuid
 
 # Remove a tag from the database
 def remove_tag(tag: str):
-    # Connect to the SQLite database
-    conn = sqlite3.connect(db_file)
-
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
-
-    # Remove a tag from the database
-    cursor.execute("DELETE FROM tags WHERE tag = ?", (tag,))
-
-    # Commit the changes
-    conn.commit()
-
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
+    _execute("DELETE FROM tags WHERE tag = ?", (tag,))
 
 def get_command_id_from_command(command):
-    # Connect to the SQLite database
-    conn = sqlite3.connect(db_file)
-
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
-
-    # Get the command_id from the commands table
-    cursor.execute("SELECT id FROM commands WHERE command = ?", (command,))
-    command_id = cursor.fetchone()[0]
-
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
-
-    return command_id
+    return _fetchone("SELECT id FROM commands WHERE command = ?", (command,))[0]
 
 def get_tag_id_from_command_id(command_id):
-    # Connect to the SQLite database
-    conn = sqlite3.connect(db_file)
-
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
-
-    # Get the tag_id from the commands_tags table
-    cursor.execute("SELECT * FROM commands_tags WHERE command_id = ?", (command_id,))
-    tag_id = cursor.fetchone()
-
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
-
-    return tag_id
+    return _fetchone("SELECT * FROM commands_tags WHERE command_id = ?", (command_id,))
 
 def get_tag_from_tag_id(tag_id):
-    # Connect to the SQLite database
-    conn = sqlite3.connect(db_file)
-
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
-
-    query = "SELECT tag FROM tags WHERE id IN ({})".format(','.join('?' for _ in tag_id))
-    cursor.execute(query, tag_id)
-
-    tag = cursor.fetchall()[0][0]
-    #tags = [row[0] for row in tag]
-
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
-
-    return tag
+    query = _select_ids_query("tags", "tag", tag_id)
+    return _fetchall(query, tuple(tag_id))[0][0]
 
 def get_tag_id_from_tag(tag):
-    # Connect to the SQLite database
-    conn = sqlite3.connect(db_file)
-    tag_id = ""
-
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
-
-    # Get the tag_id from the tags table
-    cursor.execute("SELECT id FROM tags WHERE tag = ?", (tag,))
-    try :
-        tag_id = cursor.fetchone()[0]
-    except:
-        pass
-
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
-
-    return tag_id
+    tag_row = _fetchone("SELECT id FROM tags WHERE tag = ?", (tag,))
+    return tag_row[0] if tag_row else ""
 
 def get_command_ids_from_tag_id(tag_id):
-    # Connect to the SQLite database
-    conn = sqlite3.connect(db_file)
-
-    # Create a cursor object to interact with the database
-    cursor = conn.cursor()
-
-    # Get the command_id from the commands_tags table
-    cursor.execute("SELECT * FROM commands_tags WHERE tag_id = ?", (tag_id,))
-    command_ids = cursor.fetchall()
-
-    # Close the cursor and connection
-    cursor.close()
-    conn.close()
-
-    return [id[0] for id in command_ids]
+    command_ids = _fetchall("SELECT * FROM commands_tags WHERE tag_id = ?", (tag_id,))
+    return [command_id[0] for command_id in command_ids]
 
 def get_commands_from_tag(tag):
     tag_id = get_tag_id_from_tag(tag)
@@ -427,112 +264,30 @@ class DbIntegrity:
         self.tags = ""
     
     def get_commands_ids(self):
-        # Connect to the SQLite database
-        conn = sqlite3.connect(db_file)
-
-        # Create a cursor object to interact with the database
-        cursor = conn.cursor()
-
-        # Get all commands from the database
-        cursor.execute("SELECT id FROM commands")
-
-        self.commands_ids = [command_id[0] for command_id in cursor.fetchall()]
-
-        # Close the cursor and connection
-        cursor.close()
-        conn.close()
+        self.commands_ids = [command_id[0] for command_id in _fetchall("SELECT id FROM commands")]
 
         return self.commands_ids
     
     def get_commands(self):
-        # Connect to the SQLite database
-        conn = sqlite3.connect(db_file)
-
-        # Create a cursor object to interact with the database
-        cursor = conn.cursor()
-
-        # Get all commands from the database
-        cursor.execute("SELECT command FROM commands")
-
-        self.commands = [command[0] for command in cursor.fetchall()]
-
-        # Close the cursor and connection
-        cursor.close()
-        conn.close()
+        self.commands = [command[0] for command in _fetchall("SELECT command FROM commands")]
 
         return self.commands
 
     def get_tags_ids(self):
-        # Connect to the SQLite database
-        conn = sqlite3.connect(db_file)
-
-        # Create a cursor object to interact with the database
-        cursor = conn.cursor()
-
-        # Get all tags from the database
-        cursor.execute("SELECT id FROM tags")
-
-        self.tags_ids = [tag_id[0] for tag_id in cursor.fetchall()]
-
-        # Close the cursor and connection
-        cursor.close()
-        conn.close()
+        self.tags_ids = [tag_id[0] for tag_id in _fetchall("SELECT id FROM tags")]
 
         return self.tags_ids
     
     def get_tags(self):
-        # Connect to the SQLite database
-        conn = sqlite3.connect(db_file)
-
-        # Create a cursor object to interact with the database
-        cursor = conn.cursor()
-
-        # Get all tags from the database
-        cursor.execute("SELECT tag FROM tags")
-
-        self.tags = [tag[0] for tag in cursor.fetchall()]
-
-        # Close the cursor and connection
-        cursor.close()
-        conn.close()
+        self.tags = [tag[0] for tag in _fetchall("SELECT tag FROM tags")]
 
         return self.tags
     
     def get_commands_ids_relation(self):
-        # Connect to the SQLite database
-        conn = sqlite3.connect(db_file)
-
-        # Create a cursor object to interact with the database
-        cursor = conn.cursor()
-
-        # Get all tags from the database
-        cursor.execute("SELECT command_id FROM commands_tags")
-
-        command_tag_relation = [command_id[0] for command_id in cursor.fetchall()]
-
-        # Close the cursor and connection
-        cursor.close()
-        conn.close()
-
-        return command_tag_relation
+        return [command_id[0] for command_id in _fetchall("SELECT command_id FROM commands_tags")]
 
     def get_tags_ids_relation(self):
-        # Connect to the SQLite database
-        conn = sqlite3.connect(db_file)
-
-        # Create a cursor object to interact with the database
-        cursor = conn.cursor()
-
-        # Get all tags from the database
-        cursor.execute("SELECT tag_id FROM commands_tags")
-
-        tag_command_relation = [tag_id[0] for tag_id in cursor.fetchall()]
-
-        # Close the cursor and connection
-        cursor.close()
-        conn.close()
-
-        return tag_command_relation
+        return [tag_id[0] for tag_id in _fetchall("SELECT tag_id FROM commands_tags")]
 
     def main(self):
         return self.get_commands_ids(), self.get_commands(), self.get_tags_ids(), self.get_tags(), self.get_commands_ids_relation(), self.get_tags_ids_relation()


### PR DESCRIPTION
## Summary
- reduce repeated CLI setup by centralizing `init_config()` + `CommandTable(...)` creation and import-file prompting without changing public commands or options
- refactor SQLite access through small internal helpers/context handling to simplify repeated connect/commit/rollback/close patterns
- preserve behavior while improving DB integrity safeguards around delete ordering and internal query construction

## Validation
- poetry run pytest -v -s tests/13-db_utils.py::test_get_tags_db_filters_with_grep
- poetry run pytest -v -s tests/13-db_utils.py
- poetry run pytest -v -s tests/14-cli_branches.py
- poetry run pytest -v -s tests/9-command_branches.py
- poetry run pytest -v -s tests/12-config_utils.py
- poetry run pytest -v -s tests/1-init_clir.py tests/2-add_command.py tests/3-copy_command.py tests/4-run_command.py tests/5-remove_command.py tests/6-list_command.py tests/7-import_export_command.py
- poetry run pytest -v -s tests/13-db_utils.py::test_remove_tag_deletes_tag