### PR TITLE
Clean up packaging metadata and CI workflows

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,17 +21,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build
+        pip install build twine
     - name: Build package
       run: python -m build
+    - name: Check distribution metadata
+      run: twine check dist/*
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:

--- a/.github/workflows/test-clir.yml
+++ b/.github/workflows/test-clir.yml
@@ -1,6 +1,9 @@
 name: Test Clir
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -17,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install xclip
@@ -30,10 +33,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install poetry
-      - name: Install clir using Poetry
+      - name: Install dependencies
         run: |
-          poetry install ; poetry build ; pip install .
+          poetry install
       - name: Test with pytest
         run: |
-          pip install pytest pytest-cov coverage pyperclip
-          pytest -v -s tests
+          poetry run pytest -v -s tests/1-init_clir.py tests/2-add_command.py tests/3-copy_command.py tests/4-run_command.py tests/5-remove_command.py tests/6-list_command.py tests/7-import_export_command.py

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # clir
-[![PyPI](https://img.shields.io/pypi/v/clir)](https://github.com/elkinaguas/clir/releases) ![PyPI - Downloads](https://img.shields.io/pypi/dm/clir) ![Total Download](https://static.pepy.tech/badge/clir)
+[![PyPI](https://img.shields.io/pypi/v/clir)](https://pypi.org/project/clir/) ![PyPI - Downloads](https://img.shields.io/pypi/dm/clir) ![Total Download](https://static.pepy.tech/badge/clir)
 
 Clir provides a clear and fast way to store and recover your commands.
 
@@ -10,23 +10,24 @@ Clir provides a clear and fast way to store and recover your commands.
 - Test suite and CI coverage were expanded with new branch and integration tests.
 
 ## Installation
-Install `clir` using pip3 and pipx.
+`clir` supports Python 3.9+.
 
-```bash
-pip3 install clir
-```
+Recommended:
 
 ```bash
 pipx install clir
 ```
 
-## Usage
-First of all, initialize clir. This will create the necessary cofig files.
+Alternative:
+
 ```bash
-clir init
+pip install clir
 ```
 
-See all the obption available with
+## Usage
+`clir` initializes automatically the first time you run a real command.
+
+See all the options available with
 ```bash
 clir --help
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,27 @@ name = "clir"
 version = "0.9.0"
 description = "A clear and fast way to store and recover your commands"
 authors = ["Elkin Aguas <elkinaguas@gmail.com>"]
-license = "MIT License"
+license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/elkinaguas/clir"
 repository = "https://github.com/elkinaguas/clir"
+keywords = ["cli", "commands", "terminal", "productivity", "sqlite"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Terminals",
+    "Topic :: Utilities",
+]
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/elkinaguas/clir/issues"
@@ -24,7 +41,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 clir = "clir.cli:cli"
-init_clir = 'clir.cli:init'
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- remove the obsolete init_clir console script while keeping automatic first-use initialization through the existing runtime config flow
- improve package metadata and README guidance for Python 3.9+, pipx installation, and actual first-run behavior
- modernize the publish and test workflows with newer setup actions, twine validation, push coverage, and the ordered CI test suite

## Validation
- poetry install
- poetry build
- python -m build
- twine check dist/*
- poetry run pytest -v -s tests/14-cli_branches.py
- poetry run pytest -v -s tests/12-config_utils.py
- poetry run pytest -v -s tests/1-init_clir.py tests/2-add_command.py tests/3-copy_command.py tests/4-run_command.py tests/5-remove_command.py tests/6-list_command.py tests/7-import_export_command.py