### PR TITLE
Harden import, config, and tag handling

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.11'
     - name: Install dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build twine
+        pip install build==1.4.2 twine==6.2.0
     - name: Build package
       run: python -m build
     - name: Check distribution metadata

--- a/.github/workflows/test-clir.yml
+++ b/.github/workflows/test-clir.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install poetry
         run: |
           python -m pip install --upgrade pip
-          pip install poetry
+          pip install poetry==2.2.1
       - name: Install dependencies
         run: |
           poetry install

--- a/.github/workflows/test-clir.yml
+++ b/.github/workflows/test-clir.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
@@ -18,9 +21,9 @@ jobs:
         python-version: ["3.9","3.10","3.11"]
         
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install xclip

--- a/.github/workflows/test-clir.yml
+++ b/.github/workflows/test-clir.yml
@@ -30,7 +30,7 @@ jobs:
         if: runner.os == 'Linux'  # Run only if the OS is Linux (Ubuntu)
         run: |
           sudo apt-get update
-          sudo apt-get install xorg openbox
+          sudo apt-get install -y xorg openbox
           sudo apt-get install -y xclip xsel
       - name: Install poetry
         run: |
@@ -41,4 +41,4 @@ jobs:
           poetry install
       - name: Test with pytest
         run: |
-          poetry run pytest -v -s tests/1-init_clir.py tests/2-add_command.py tests/3-copy_command.py tests/4-run_command.py tests/5-remove_command.py tests/6-list_command.py tests/7-import_export_command.py
+          poetry run pytest -v -s tests/1-init_clir.py tests/2-add_command.py tests/3-copy_command.py tests/4-run_command.py tests/5-remove_command.py tests/6-list_command.py tests/7-import_export_command.py tests/9-command_branches.py tests/10-import_export_edges.py tests/12-config_utils.py tests/13-db_utils.py tests/14-cli_branches.py

--- a/clir/cli.py
+++ b/clir/cli.py
@@ -65,7 +65,10 @@ def tags(grep: str = ""):
 @click.option('-f', '--file', help="Import file path")
 def imports(file: str = ""):
     init_config()
-    CommandTable().import_commands(import_file_path=_prompt_import_file(file))
+    try:
+        CommandTable().import_commands(import_file_path=_prompt_import_file(file))
+    except (FileNotFoundError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
 
 @cli.command(help="Export commands to file 📤")
 @click.option('-t', '--tag', help="Search by tag")

--- a/clir/cli.py
+++ b/clir/cli.py
@@ -11,9 +11,9 @@ def cli():
     pass
 
 
-def _get_command_table(tag: str = "", grep: str = "") -> CommandTable:
+def _get_command_table(tag: str = "", grep: str = "", tag_grep: str = "") -> CommandTable:
     init_config()
-    return CommandTable(tag=tag, grep=grep)
+    return CommandTable(tag=tag, grep=grep, tag_grep=tag_grep)
 
 
 def _prompt_import_file(file_path: str = "") -> str:
@@ -59,7 +59,7 @@ def cp(tag: str = "", grep: str = ""):
 @cli.command(help="Show tags 🏷️")
 @click.option('-g', '--grep', help="Search by grep")
 def tags(grep: str = ""):
-    _get_command_table(grep=grep).show_tags()
+    _get_command_table(tag_grep=grep).show_tags()
 
 @cli.command(help="Import commands from file 🤓")
 @click.option('-f', '--file', help="Search by grep")

--- a/clir/cli.py
+++ b/clir/cli.py
@@ -62,7 +62,7 @@ def tags(grep: str = ""):
     _get_command_table(tag_grep=grep).show_tags()
 
 @cli.command(help="Import commands from file 🤓")
-@click.option('-f', '--file', help="Search by grep")
+@click.option('-f', '--file', help="Import file path")
 def imports(file: str = ""):
     init_config()
     CommandTable().import_commands(import_file_path=_prompt_import_file(file))

--- a/clir/command.py
+++ b/clir/command.py
@@ -51,10 +51,12 @@ class Command:
 
 #Create class Table
 class CommandTable:
-    def __init__(self, tag: str = "", grep: str = ""):
+    def __init__(self, tag: str = "", grep: str = "", tag_grep: str = ""):
         self.commands = transform_commands_to_json(get_commands_db(tag = tag, grep = grep))
+        self.tags = get_tags_db(grep=tag_grep) if tag_grep else []
         self.tag = tag
         self.grep = grep
+        self.tag_grep = tag_grep
 
     def __str__(self):
         return f"{self.command} {self.description} {self.tag}"
@@ -158,13 +160,14 @@ class CommandTable:
                 print("OS not supported")
     
     def show_tags(self):
-        current_commands = self.commands
+        if getattr(self, "tag_grep", ""):
+            tags = [tag_row[3] for tag_row in getattr(self, "tags", [])]
+        else:
+            tags = []
+            for command in self.commands:
+                tags.append(self.commands[command]["tag"])
 
-        tags = []
-        for command in current_commands:
-            tags.append(current_commands[command]["tag"])
-        
-        tags = list(dict.fromkeys(tags))
+            tags = list(dict.fromkeys(tags))
 
         table = Table(show_lines=True, box=box.ROUNDED, style="grey46")
         table.add_column("Tags 🏷️", style="cyan bold")
@@ -203,6 +206,7 @@ class CommandTable:
             else:
                 raise FileNotFoundError(f"File '{import_file_path}' could not be found")
 
+            import_commands = self._validate_import_commands_payload(import_commands)
 
             for command, data in import_commands.items():
                 if command in existing_commands.keys() \
@@ -214,7 +218,7 @@ class CommandTable:
                 elif command in existing_commands.keys() \
                 and (data['description'] != existing_commands[command]["description"] or data['tag'] != existing_commands[command]["tag"]):
                     import_choice = ""
-                    print("The command [bold green]{command}[/bold green] already exists in the database:")
+                    print(f"The command [bold green]{command}[/bold green] already exists in the database:")
                     print(data)
                     table = Table(show_lines=True, box=box.ROUNDED, style="grey46")
                     table.add_column("", style="white bold", no_wrap=True)
@@ -254,6 +258,28 @@ class CommandTable:
             print("Import complete")
         else:
             print("No file was passed to import")
+
+    def _validate_import_commands_payload(self, import_commands):
+        required_keys = {"description", "tag", "creation_date", "last_modif_date"}
+
+        if not isinstance(import_commands, dict):
+            raise ValueError("Import payload must be a JSON object mapping commands to metadata")
+
+        for command, data in import_commands.items():
+            if not isinstance(command, str) or not command:
+                raise ValueError("Import payload commands must be non-empty strings")
+
+            if not isinstance(data, dict):
+                raise ValueError(f"Import payload for command '{command}' must be an object")
+
+            missing_keys = sorted(required_keys - data.keys())
+            if missing_keys:
+                missing = ", ".join(missing_keys)
+                raise ValueError(
+                    f"Import payload for command '{command}' is missing required key(s): {missing}"
+                )
+
+        return import_commands
 
     # Create a function that deletes a command when passing its uid
     def remove_command(self):

--- a/clir/command.py
+++ b/clir/command.py
@@ -194,7 +194,7 @@ class CommandTable:
             existing_commands = self.commands
 
 
-            if os.path.exists(import_file_path):
+            if os.path.isfile(import_file_path):
                 try:
                     with open(import_file_path, 'r') as import_file:
                         print(f"Importing commands from {import_file_path}...")
@@ -261,6 +261,7 @@ class CommandTable:
 
     def _validate_import_commands_payload(self, import_commands):
         required_keys = {"description", "tag", "creation_date", "last_modif_date"}
+        string_keys = {"description", "tag", "creation_date", "last_modif_date"}
 
         if not isinstance(import_commands, dict):
             raise ValueError("Import payload must be a JSON object mapping commands to metadata")
@@ -278,6 +279,13 @@ class CommandTable:
                 raise ValueError(
                     f"Import payload for command '{command}' is missing required key(s): {missing}"
                 )
+
+            for key in string_keys:
+                value = data[key]
+                if not isinstance(value, str):
+                    raise ValueError(
+                        f"Import payload for command '{command}' has invalid value for '{key}': expected a string"
+                    )
 
         return import_commands
 

--- a/clir/command.py
+++ b/clir/command.py
@@ -46,7 +46,7 @@ class Command:
 
         insert_command_db(command, desc, tag)
 
-        print(f'Command saved successfuly')
+        print('Command saved successfully')
 
 
 #Create class Table
@@ -183,7 +183,7 @@ class CommandTable:
         try:
             with open("commands.json", "w") as commands_file:
                 json.dump(self.commands, commands_file)
-            print(f"[bold green]Commands exported succesfully[/bold green] to {os.getcwd()}/commands.json")
+            print(f"[bold green]Commands exported successfully[/bold green] to {os.getcwd()}/commands.json")
         except OSError:
             print("[bold red]Commands could not be exported[/bold red]")
             raise
@@ -228,7 +228,7 @@ class CommandTable:
                     table.add_row("Description", data['description'], existing_commands[command]["description"])
                     table.add_row("Tag", data['tag'], existing_commands[command]["tag"])
                     table.add_row("Creation date", data['creation_date'], existing_commands[command]["creation_date"])
-                    table.add_row("Laste modification date", data['last_modif_date'], existing_commands[command]["last_modif_date"])
+                    table.add_row("Last modification date", data['last_modif_date'], existing_commands[command]["last_modif_date"])
                     console = Console()
                     console.print(table)
 
@@ -303,11 +303,11 @@ class CommandTable:
                 print(f'Command [bold green]{command_name}[/bold green] not removed.')
             elif not verify_command_id_exists(uid) and verify_command_id_tag_relation_exists(uid):
                 print(
-                    f'Command [bold green]{command_name}[/bold green] '
-                    'removed successfuly but relation to tag not removed.'
-                )
+                        f'Command [bold green]{command_name}[/bold green] '
+                        'removed successfully but relation to tag not removed.'
+                    )
             elif not verify_command_id_exists(uid) and not verify_command_id_tag_relation_exists(uid):
-                print(f'Command [bold green]{command_name}[/bold green] removed successfuly.')
+                print(f'Command [bold green]{command_name}[/bold green] removed successfully.')
         
         remove_tag_if_no_commands(tag_uids)
         

--- a/clir/utils/config.py
+++ b/clir/utils/config.py
@@ -1,31 +1,44 @@
-import os
+import importlib.resources
 import shutil
 from pathlib import Path
-from clir.utils.db import create_database
+
 from clir.utils.core import get_commands
+from clir.utils.db import create_database
 from clir.utils.db import insert_command_db
-import importlib.resources
 
 config_directory = "clir/config/"
-env_path = Path('~').expanduser() / Path(".clir")
+
+
+def _env_path() -> Path:
+    return Path.home() / ".clir"
+
+
+def _commands_json_path() -> Path:
+    return _env_path() / "commands.json"
+
+
+def _config_file_path() -> Path:
+    return _env_path() / "clir.conf"
+
+
+def _db_file_path() -> Path:
+    return _env_path() / "clir.db"
 
 def check_config():
-    dir_path = os.path.join(os.path.expanduser('~'), '.clir')
-    db_file_path = os.path.join(dir_path, 'clir.db')
-    config_file_path = os.path.join(dir_path, 'clir.conf')
-
-    return os.path.exists(db_file_path) and os.path.exists(config_file_path)
+    return _db_file_path().exists() and _config_file_path().exists()
 
 def back_json_commands():
-    source_file = f"{env_path}/commands.json"
-    destination_file = f"{env_path}/commands.json.backup"
+    source_file = _commands_json_path()
+    destination_file = _env_path() / "commands.json.backup"
 
     shutil.copyfile(source_file, destination_file)
 
     print(f"Backup of json commands stored in {source_file} to {destination_file} complete.")
 
 def migrate_json_to_sqlite():
-    if os.path.exists(f"{env_path}/commands.json"):
+    commands_json_path = _commands_json_path()
+
+    if commands_json_path.exists():
         back_json_commands()
         print("Migrating json stored commands to sqlite database...")
         
@@ -38,21 +51,21 @@ def migrate_json_to_sqlite():
             insert_command_db(command, data['description'], data['tag'])
             print("---")
 
-        os.remove(f"{env_path}/commands.json")
+        commands_json_path.unlink()
         print("Migration complete")
 
 
 def create_config_files():
-    dir_path = os.path.join(os.path.expanduser('~'), '.clir')
-    os.makedirs(dir_path, exist_ok=True)
+    dir_path = _env_path()
+    dir_path.mkdir(parents=True, exist_ok=True)
     
     # Define the file path and name
     files = ['commands.json']
 
     # Check if the file already exists
     for file in files:
-        file_path = os.path.join(dir_path, file)
-        if not os.path.exists(file_path):
+        file_path = dir_path / file
+        if not file_path.exists():
             # Create the file
             with open(file_path, 'w') as file_object:
                 file_object.write('{}')
@@ -62,25 +75,25 @@ def create_config_files():
             print(f'A clir environment already exists in "{dir_path}".')
 
 def copy_config_files():
-    dir_path = os.path.join(os.path.expanduser('~'), '.clir')
-    os.makedirs(dir_path, exist_ok=True)
+    dir_path = _env_path()
+    dir_path.mkdir(parents=True, exist_ok=True)
     
     # Define the file path and name
     files = ['clir.conf']
 
     # Check if the file already exists
-    for file in files:
+    for file_name in files:
         with importlib.resources.open_text('clir.config', 'clir.conf') as f:
             conf = f.read()
-            with open(f"{env_path}/{file}", "w") as file:
-                file.write(conf)
+            with open(dir_path / file_name, "w") as file_object:
+                file_object.write(conf)
 
-        print(f"Copying {file} file to {env_path}")
+        print(f"Copying {file_name} file to {dir_path}")
 
 def init_config():
     if not check_config():
-        dir_path = os.path.join(os.path.expanduser('~'), '.clir')
-        os.makedirs(dir_path, exist_ok=True)
+        dir_path = _env_path()
+        dir_path.mkdir(parents=True, exist_ok=True)
 
         print("Setting up initial configuration")
         print("Creating database...")

--- a/clir/utils/db.py
+++ b/clir/utils/db.py
@@ -12,8 +12,17 @@ db_file_name = "clir.db"
 sql_schema_path = Path(schema_directory) / schema_file_name
 db_user_version = 1
 
-env_path = Path('~').expanduser() / Path(".clir")
-db_file = Path(env_path) / db_file_name
+
+
+def _env_path() -> Path:
+    return Path.home() / ".clir"
+
+
+def _default_db_file() -> Path:
+    return _env_path() / db_file_name
+
+
+db_file = None
 
 
 def _timestamp_now() -> str:
@@ -22,8 +31,10 @@ def _timestamp_now() -> str:
 
 @contextmanager
 def _db_connection(database_name=None):
-    connection = sqlite3.connect(database_name or db_file)
+    database_path = database_name or db_file or _default_db_file()
+    connection = sqlite3.connect(database_path)
     try:
+        connection.execute("PRAGMA foreign_keys = ON")
         yield connection
         connection.commit()
     except Exception:
@@ -237,8 +248,23 @@ def get_tag_id_from_command_id(command_id):
     return _fetchone("SELECT * FROM commands_tags WHERE command_id = ?", (command_id,))
 
 def get_tag_from_tag_id(tag_id):
-    query = _select_ids_query("tags", "tag", tag_id)
-    return _fetchall(query, tuple(tag_id))[0][0]
+    if isinstance(tag_id, str):
+        tag_values = (tag_id,)
+    elif isinstance(tag_id, (list, tuple)):
+        tag_values = tuple(tag_id)
+    else:
+        raise TypeError("tag_id must be a string, list, or tuple")
+
+    if not tag_values:
+        return ""
+
+    query = _select_ids_query("tags", "tag", tag_values)
+    tag_rows = _fetchall(query, tag_values)
+
+    if not tag_rows:
+        return ""
+
+    return tag_rows[0][0]
 
 def get_tag_id_from_tag(tag):
     tag_row = _fetchone("SELECT id FROM tags WHERE tag = ?", (tag,))

--- a/tests/10-import_export_edges.py
+++ b/tests/10-import_export_edges.py
@@ -62,6 +62,29 @@ def test_import_commands_raises_for_non_object_command_metadata(tmp_path):
         table.import_commands(str(invalid_file))
 
 
+def test_import_commands_raises_for_non_string_metadata_values(tmp_path):
+    table = object.__new__(CommandTable)
+    table.commands = {}
+
+    invalid_file = tmp_path / "broken.json"
+    invalid_file.write_text(
+        json.dumps(
+            {
+                "echo hi": {
+                    "description": ["not", "a", "string"],
+                    "tag": "ops",
+                    "creation_date": "2023-01-01 00:00:00.000",
+                    "last_modif_date": "2023-01-01 00:00:00.000",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="has invalid value for 'description': expected a string"):
+        table.import_commands(str(invalid_file))
+
+
 def test_import_existing_command_with_no_changes_skips_write(tmp_path, monkeypatch):
     table = object.__new__(CommandTable)
     table.commands = {

--- a/tests/10-import_export_edges.py
+++ b/tests/10-import_export_edges.py
@@ -26,6 +26,42 @@ def test_import_commands_raises_for_invalid_json(tmp_path):
         table.import_commands(str(invalid_file))
 
 
+def test_import_commands_raises_for_non_object_payload(tmp_path):
+    table = object.__new__(CommandTable)
+    table.commands = {}
+
+    invalid_file = tmp_path / "broken.json"
+    invalid_file.write_text(json.dumps(["echo hi"]), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Import payload must be a JSON object"):
+        table.import_commands(str(invalid_file))
+
+
+def test_import_commands_raises_for_missing_required_keys(tmp_path):
+    table = object.__new__(CommandTable)
+    table.commands = {}
+
+    invalid_file = tmp_path / "broken.json"
+    invalid_file.write_text(
+        json.dumps({"echo hi": {"description": "desc", "tag": "ops"}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"missing required key\(s\): creation_date, last_modif_date"):
+        table.import_commands(str(invalid_file))
+
+
+def test_import_commands_raises_for_non_object_command_metadata(tmp_path):
+    table = object.__new__(CommandTable)
+    table.commands = {}
+
+    invalid_file = tmp_path / "broken.json"
+    invalid_file.write_text(json.dumps({"echo hi": "desc"}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Import payload for command 'echo hi' must be an object"):
+        table.import_commands(str(invalid_file))
+
+
 def test_import_existing_command_with_no_changes_skips_write(tmp_path, monkeypatch):
     table = object.__new__(CommandTable)
     table.commands = {
@@ -96,6 +132,7 @@ def test_import_existing_command_with_changes_and_accepts_replace(tmp_path, monk
         "modify_command_db",
         lambda *args, **kwargs: modify_calls.append(args),
     )
+    monkeypatch.setattr(command_module, "print", lambda *args, **kwargs: None)
 
     table.import_commands(str(import_file))
 
@@ -103,6 +140,41 @@ def test_import_existing_command_with_changes_and_accepts_replace(tmp_path, monk
     assert modify_calls[0][0] == "echo hi"
     assert modify_calls[0][1] == "new"
     assert modify_calls[0][2] == "new-tag"
+
+
+def test_import_existing_command_replace_prompt_prints_command_name(tmp_path, monkeypatch):
+    table = object.__new__(CommandTable)
+    table.commands = {
+        "echo hi": {
+            "description": "old",
+            "tag": "old-tag",
+            "creation_date": "2023-01-01 00:00:00.000",
+            "last_modif_date": "2023-01-01 00:00:00.000",
+        }
+    }
+
+    import_file = tmp_path / "import.json"
+    import_file.write_text(
+        json.dumps(
+            {
+                "echo hi": {
+                    "description": "new",
+                    "tag": "new-tag",
+                    "creation_date": "2023-01-01 00:00:00.000",
+                    "last_modif_date": "2023-01-02 00:00:00.000",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    messages = []
+    monkeypatch.setattr(command_module.Prompt, "ask", lambda _: "n")
+    monkeypatch.setattr(command_module, "print", lambda *args, **kwargs: messages.append(args[0]))
+
+    table.import_commands(str(import_file))
+
+    assert "The command [bold green]echo hi[/bold green] already exists in the database:" in messages
 
 
 def test_import_existing_command_with_changes_and_declines_replace(tmp_path, monkeypatch):

--- a/tests/12-config_utils.py
+++ b/tests/12-config_utils.py
@@ -11,6 +11,16 @@ def test_create_config_files_creates_commands_json(monkeypatch, tmp_path):
     assert commands_file.read_text(encoding="utf-8") == "{}"
 
 
+def test_check_config_uses_current_home_at_call_time(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    clir_dir = tmp_path / ".clir"
+    clir_dir.mkdir(parents=True)
+    (clir_dir / "clir.db").write_text("db", encoding="utf-8")
+    (clir_dir / "clir.conf").write_text("conf", encoding="utf-8")
+
+    assert config_module.check_config() is True
+
+
 def test_create_config_files_keeps_existing_commands_json(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
     clir_dir = tmp_path / ".clir"
@@ -21,6 +31,14 @@ def test_create_config_files_keeps_existing_commands_json(monkeypatch, tmp_path)
     config_module.create_config_files()
 
     assert commands_file.read_text(encoding="utf-8") == '{"existing": true}'
+
+
+def test_copy_config_files_uses_current_home_at_call_time(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    config_module.copy_config_files()
+
+    assert (tmp_path / ".clir" / "clir.conf").exists()
 
 
 def test_init_config_returns_when_setup_cannot_be_completed(monkeypatch):

--- a/tests/13-db_utils.py
+++ b/tests/13-db_utils.py
@@ -33,6 +33,15 @@ def test_insert_command_db_sets_last_modif_when_only_creation_date(monkeypatch, 
     assert last_modif_date
 
 
+def test_db_connection_enables_foreign_keys(monkeypatch, tmp_path):
+    temp_db = _setup_temp_db(monkeypatch, tmp_path)
+
+    with db_module._db_connection(temp_db) as conn:
+        pragma_value = conn.execute("PRAGMA foreign_keys").fetchone()[0]
+
+    assert pragma_value == 1
+
+
 def test_insert_command_db_sets_creation_when_only_last_modif_date(monkeypatch, tmp_path):
     temp_db = _setup_temp_db(monkeypatch, tmp_path)
 
@@ -113,3 +122,17 @@ def test_get_tag_id_from_tag_returns_empty_when_missing(monkeypatch, tmp_path):
     _setup_temp_db(monkeypatch, tmp_path)
 
     assert db_module.get_tag_id_from_tag("missing-tag") == ""
+
+
+def test_get_tag_from_tag_id_returns_empty_when_missing(monkeypatch, tmp_path):
+    _setup_temp_db(monkeypatch, tmp_path)
+
+    assert db_module.get_tag_from_tag_id(()) == ""
+
+
+def test_get_tag_from_tag_id_accepts_string(monkeypatch, tmp_path):
+    _setup_temp_db(monkeypatch, tmp_path)
+
+    tag_uuid = db_module.insert_tag("ops")
+
+    assert db_module.get_tag_from_tag_id(tag_uuid) == "ops"

--- a/tests/14-cli_branches.py
+++ b/tests/14-cli_branches.py
@@ -81,3 +81,45 @@ def test_settings_calls_init_config(monkeypatch):
 
     assert result.exit_code == 0
     assert calls["init"] == 1
+
+
+def test_imports_shows_click_error_for_missing_file(monkeypatch):
+    runner = CliRunner()
+    calls = {"init": 0}
+
+    class FakeTable:
+        def import_commands(self, import_file_path=""):
+            raise FileNotFoundError(f"File '{import_file_path}' could not be found")
+
+    def fake_init():
+        calls["init"] += 1
+
+    monkeypatch.setattr(cli_module, "init_config", fake_init)
+    monkeypatch.setattr(cli_module, "CommandTable", lambda: FakeTable())
+
+    result = runner.invoke(cli_module.imports, ["-f", "missing.json"])
+
+    assert result.exit_code == 1
+    assert calls["init"] == 1
+    assert "File 'missing.json' could not be found" in result.output
+
+
+def test_imports_shows_click_error_for_invalid_payload(monkeypatch):
+    runner = CliRunner()
+    calls = {"init": 0}
+
+    class FakeTable:
+        def import_commands(self, import_file_path=""):
+            raise ValueError("Import payload must be a JSON object mapping commands to metadata")
+
+    def fake_init():
+        calls["init"] += 1
+
+    monkeypatch.setattr(cli_module, "init_config", fake_init)
+    monkeypatch.setattr(cli_module, "CommandTable", lambda: FakeTable())
+
+    result = runner.invoke(cli_module.imports, ["-f", "broken.json"])
+
+    assert result.exit_code == 1
+    assert calls["init"] == 1
+    assert "Import payload must be a JSON object mapping commands to metadata" in result.output

--- a/tests/14-cli_branches.py
+++ b/tests/14-cli_branches.py
@@ -13,8 +13,9 @@ def test_tags_command_calls_show_tags(monkeypatch):
     calls = {}
 
     class FakeTable:
-        def __init__(self, tag="", grep=""):
+        def __init__(self, tag="", grep="", tag_grep=""):
             calls["grep"] = grep
+            calls["tag_grep"] = tag_grep
 
         def show_tags(self):
             calls["show_tags"] = True
@@ -29,7 +30,8 @@ def test_tags_command_calls_show_tags(monkeypatch):
 
     assert result.exit_code == 0
     assert calls["init"] == 1
-    assert calls["grep"] == "ops"
+    assert calls["grep"] == ""
+    assert calls["tag_grep"] == "ops"
     assert calls["show_tags"] is True
 
 

--- a/tests/5-remove_command.py
+++ b/tests/5-remove_command.py
@@ -99,8 +99,8 @@ def test_remove_commands_bulk_with_range_and_commas():
     remove_result = runner.invoke(rm, ["-t", "bulk-delete-tag"], input="1-2\nn\n")
 
     assert remove_result.exit_code == 0
-    assert "Command bulk-delete-command-1 removed successfuly." in remove_result.output
-    assert "Command bulk-delete-command-2 removed successfuly." in remove_result.output
+    assert "Command bulk-delete-command-1 removed successfully." in remove_result.output
+    assert "Command bulk-delete-command-2 removed successfully." in remove_result.output
 
     copy_result = runner.invoke(cp, ["-t", "bulk-delete-tag"], input="1\n")
     assert copy_result.exit_code == 1
@@ -138,8 +138,8 @@ def test_remove_commands_bulk_with_all_keyword():
     remove_result = runner.invoke(rm, ["-t", "bulk-all-tag"], input="all\nn\n")
 
     assert remove_result.exit_code == 0
-    assert "Command bulk-all-command-1 removed successfuly." in remove_result.output
-    assert "Command bulk-all-command-2 removed successfuly." in remove_result.output
+    assert "Command bulk-all-command-1 removed successfully." in remove_result.output
+    assert "Command bulk-all-command-2 removed successfully." in remove_result.output
 
     copy_result = runner.invoke(cp, ["-t", "bulk-all-tag"], input="1\n")
     assert copy_result.exit_code == 1

--- a/tests/9-command_branches.py
+++ b/tests/9-command_branches.py
@@ -250,6 +250,52 @@ def test_copy_command_shows_clipboard_failure_on_darwin(monkeypatch):
     ]
 
 
+def test_copy_command_shows_oserror_failure_on_linux(monkeypatch):
+    table = object.__new__(CommandTable)
+    table.commands = {"echo hello": {"uid": "uid-1"}}
+
+    messages = []
+
+    def fail(*args, **kwargs):
+        raise OSError("xclip unavailable")
+
+    monkeypatch.setattr(CommandTable, "get_command_uid", lambda self: "uid-1")
+    monkeypatch.setattr(command_module.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(command_module, "verify_clipboard_tool_installation", lambda package: True)
+    monkeypatch.setattr(command_module.subprocess, "run", fail)
+    monkeypatch.setattr(command_module, "print", lambda *args, **kwargs: messages.append(args[0]))
+
+    table.copy_command()
+
+    assert messages == [
+        "Copying command: echo hello",
+        "xclip failed to copy the command. Please verify clipboard access and try again",
+    ]
+
+
+def test_copy_command_shows_oserror_failure_on_darwin(monkeypatch):
+    table = object.__new__(CommandTable)
+    table.commands = {"echo hello": {"uid": "uid-1"}}
+
+    messages = []
+
+    def fail(*args, **kwargs):
+        raise OSError("pbcopy unavailable")
+
+    monkeypatch.setattr(CommandTable, "get_command_uid", lambda self: "uid-1")
+    monkeypatch.setattr(command_module.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(command_module, "verify_clipboard_tool_installation", lambda package: True)
+    monkeypatch.setattr(command_module.subprocess, "run", fail)
+    monkeypatch.setattr(command_module, "print", lambda *args, **kwargs: messages.append(args[0]))
+
+    table.copy_command()
+
+    assert messages == [
+        "Copying command: echo hello",
+        "pbcopy failed to copy the command. Please verify clipboard access and try again",
+    ]
+
+
 def test_show_tags_renders_unique_tags(monkeypatch):
     table = object.__new__(CommandTable)
     table.commands = {


### PR DESCRIPTION
## Summary
- harden import validation and clipboard/config edge handling with clearer errors and targeted regression coverage
- resolve config and default DB paths at call time, enable SQLite foreign keys, and tighten tag lookup behavior
- make `tags -g` grep tag names directly and lock workflow permissions/action SHAs for safer CI

## Validation
- poetry run pytest -v -s tests/10-import_export_edges.py::test_import_commands_raises_for_missing_required_keys
- poetry run pytest -v -s tests/9-command_branches.py
- poetry run pytest -v -s tests/10-import_export_edges.py
- poetry run pytest -v -s tests/12-config_utils.py
- poetry run pytest -v -s tests/13-db_utils.py
- poetry run pytest -v -s tests/14-cli_branches.py
- poetry run pytest -v -s tests/1-init_clir.py tests/2-add_command.py tests/3-copy_command.py tests/4-run_command.py tests/5-remove_command.py tests/6-list_command.py tests/7-import_export_command.py
- poetry build
- poetry run python -m pip install build twine && poetry run python -m build && poetry run twine check dist/*