### PR TITLE
Document disabled Test Clir triggers

### DIFF
--- a/.github/workflows/test-clir.yml
+++ b/.github/workflows/test-clir.yml
@@ -1,12 +1,15 @@
 name: Test Clir
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  # Temporarily disabled while migrating to self-hosted runners.
+  # Re-enable these when hosted-runner cost is no longer a concern.
+  # push:
+  #   branches:
+  #     - main
+  # pull_request:
+  #   branches:
+  #     - main
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- keep the Test Clir workflow manually runnable with `workflow_dispatch`
- comment the previous `push` and `pull_request` triggers so they are easy to restore after self-hosted runners are ready
- add an inline note explaining why the automatic triggers are disabled

## Validation
- workflow file updated to preserve the prior trigger configuration as comments