### PR TITLE
feat: local per-project DB support

### DIFF
--- a/clir/cli.py
+++ b/clir/cli.py
@@ -1,9 +1,21 @@
 import rich_click as click
+from pathlib import Path
+from rich import box
+from rich import print
+from rich.console import Console
 from rich.prompt import Prompt
+from rich.table import Table
 
 from clir.command import Command
 from clir.command import CommandTable
-from clir.utils.config import init_config
+from clir.utils.config import (
+    configure_active_db,
+    init_config,
+    init_local_config,
+    read_setting,
+    write_setting,
+)
+from clir.utils.db import find_local_db, get_active_db_path
 
 
 @click.group()
@@ -11,8 +23,9 @@ def cli():
     pass
 
 
-def _get_command_table(tag: str = "", grep: str = "", tag_grep: str = "") -> CommandTable:
+def _get_command_table(tag: str = "", grep: str = "", tag_grep: str = "", use_local: bool = False, use_global: bool = False) -> CommandTable:
     init_config()
+    _setup_db(use_local, use_global)
     return CommandTable(tag=tag, grep=grep, tag_grep=tag_grep)
 
 
@@ -22,60 +35,157 @@ def _prompt_import_file(file_path: str = "") -> str:
     return file_path
 
 
+def _setup_db(use_local: bool, use_global: bool) -> None:
+    try:
+        configure_active_db(use_local, use_global)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+def _find_git_root() -> Path:
+    current = Path.cwd()
+    while True:
+        if (current / ".git").exists():
+            return current
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return None
+
+
+@cli.command(help="Initialize local project DB 📁")
+def init():
+    init_config()
+
+    local_db = Path.cwd() / ".clir" / "clir.db"
+    if local_db.exists():
+        print(f"Local clir project already initialized at [bold]{local_db.parent}[/bold]")
+        return
+
+    init_local_config(Path.cwd())
+    print(f"[bold green]Local clir project initialized[/bold green] at {local_db}")
+
+    git_root = _find_git_root()
+    if git_root:
+        gitignore = git_root / ".gitignore"
+        if gitignore.exists():
+            content = gitignore.read_text()
+            if ".clir" not in content:
+                add = Prompt.ask("Add .clir/ to .gitignore?", choices=["y", "n"], default="y")
+                if add == "y":
+                    with open(gitignore, "a") as f:
+                        f.write("\n# clir local project\n.clir/\n")
+                    print(f"Added [bold].clir/[/bold] to {gitignore}")
+        else:
+            create = Prompt.ask(f"No .gitignore found at {git_root}. Create one with .clir/?", choices=["y", "n"], default="y")
+            if create == "y":
+                with open(gitignore, "w") as f:
+                    f.write("# clir local project\n.clir/\n")
+                print(f"Created {gitignore} with [bold].clir/[/bold]")
+
 
 @cli.command(help="Save new command 💾")
 @click.option('-c', '--command', help="Command to be saved", prompt=True)
 @click.option('-d', '--description', help="Description of the command", prompt=True)
 @click.option('-t', '--tag', help="Tag to be associated with the command", prompt=True)
-def new(command, description, tag):
+@click.option('-l', '--local', 'use_local', is_flag=True, help="Use local project DB")
+@click.option('-G', '--global', 'use_global', is_flag=True, help="Force global DB")
+def new(command, description, tag, use_local, use_global):
     init_config()
+    _setup_db(use_local, use_global)
     new_command = Command(command=command, description=description, tag=tag)
     new_command.save_command()
+
 
 @cli.command(help="Remove command(s) 👋. In the prompt use 1,3-5 or all")
 @click.option('-t', '--tag', help="Search by tag")
 @click.option('-g', '--grep', help="Search by grep")
-def rm(tag: str = "", grep: str = ""):
-    _get_command_table(tag=tag, grep=grep).remove_command()
+@click.option('-l', '--local', 'use_local', is_flag=True, help="Use local project DB")
+@click.option('-G', '--global', 'use_global', is_flag=True, help="Force global DB")
+def rm(tag: str = "", grep: str = "", use_local: bool = False, use_global: bool = False):
+    _get_command_table(tag=tag, grep=grep, use_local=use_local, use_global=use_global).remove_command()
+
 
 @cli.command(help="List commands 📃")
 @click.option('-t', '--tag', help="Search by tag")
 @click.option('-g', '--grep', help="Search by grep")
-def ls(tag: str = "", grep: str = ""):
-    _get_command_table(tag=tag, grep=grep).show_table()
+@click.option('-l', '--local', 'use_local', is_flag=True, help="Use local project DB")
+@click.option('-G', '--global', 'use_global', is_flag=True, help="Force global DB")
+def ls(tag: str = "", grep: str = "", use_local: bool = False, use_global: bool = False):
+    _get_command_table(tag=tag, grep=grep, use_local=use_local, use_global=use_global).show_table()
+
 
 @cli.command(help="Run command 🚀")
 @click.option('-t', '--tag', help="Search by tag")
 @click.option('-g', '--grep', help="Search by grep")
-def run(tag: str = "", grep: str = ""):
-    _get_command_table(tag=tag, grep=grep).run_command()
+@click.option('-l', '--local', 'use_local', is_flag=True, help="Use local project DB")
+@click.option('-G', '--global', 'use_global', is_flag=True, help="Force global DB")
+def run(tag: str = "", grep: str = "", use_local: bool = False, use_global: bool = False):
+    _get_command_table(tag=tag, grep=grep, use_local=use_local, use_global=use_global).run_command()
+
 
 @cli.command(help="Copy command to clipboard 📋")
 @click.option('-t', '--tag', help="Search by tag")
 @click.option('-g', '--grep', help="Search by grep")
-def cp(tag: str = "", grep: str = ""):
-    _get_command_table(tag=tag, grep=grep).copy_command()
+@click.option('-l', '--local', 'use_local', is_flag=True, help="Use local project DB")
+@click.option('-G', '--global', 'use_global', is_flag=True, help="Force global DB")
+def cp(tag: str = "", grep: str = "", use_local: bool = False, use_global: bool = False):
+    _get_command_table(tag=tag, grep=grep, use_local=use_local, use_global=use_global).copy_command()
+
 
 @cli.command(help="Show tags 🏷️")
 @click.option('-g', '--grep', help="Search by grep")
-def tags(grep: str = ""):
-    _get_command_table(tag_grep=grep).show_tags()
+@click.option('-l', '--local', 'use_local', is_flag=True, help="Use local project DB")
+@click.option('-G', '--global', 'use_global', is_flag=True, help="Force global DB")
+def tags(grep: str = "", use_local: bool = False, use_global: bool = False):
+    _get_command_table(tag_grep=grep, use_local=use_local, use_global=use_global).show_tags()
+
 
 @cli.command(help="Import commands from file 🤓")
 @click.option('-f', '--file', help="Import file path")
-def imports(file: str = ""):
+@click.option('-l', '--local', 'use_local', is_flag=True, help="Use local project DB")
+@click.option('-G', '--global', 'use_global', is_flag=True, help="Force global DB")
+def imports(file: str = "", use_local: bool = False, use_global: bool = False):
     init_config()
+    _setup_db(use_local, use_global)
     try:
         CommandTable().import_commands(import_file_path=_prompt_import_file(file))
     except (FileNotFoundError, ValueError) as exc:
         raise click.ClickException(str(exc)) from exc
 
+
 @cli.command(help="Export commands to file 📤")
 @click.option('-t', '--tag', help="Search by tag")
 @click.option('-g', '--grep', help="Search by grep")
-def export(tag: str = "", grep: str = ""):
-    _get_command_table(tag=tag, grep=grep).export_commands()
+@click.option('-l', '--local', 'use_local', is_flag=True, help="Use local project DB")
+@click.option('-G', '--global', 'use_global', is_flag=True, help="Force global DB")
+def export(tag: str = "", grep: str = "", use_local: bool = False, use_global: bool = False):
+    _get_command_table(tag=tag, grep=grep, use_local=use_local, use_global=use_global).export_commands()
+
 
 @cli.command(help="Settings ⚙️")
-def settings():
+@click.option('--default-local/--no-default-local', default=None, help="Always use local DB when available")
+def settings(default_local):
     init_config()
+
+    if default_local is not None:
+        write_setting("default_current_folder", default_local)
+        state = "enabled" if default_local else "disabled"
+        print(f"Setting [bold cyan]default_current_folder[/bold cyan] {state}.")
+        return
+
+    active_db = get_active_db_path()
+    home_db = Path.home() / ".clir" / "clir.db"
+    is_local = active_db != home_db
+    scope = "local" if is_local else "global"
+    default_local_value = read_setting("default_current_folder") or False
+
+    table = Table(show_lines=True, box=box.ROUNDED, style="grey46")
+    table.add_column("Setting", style="cyan bold", no_wrap=True)
+    table.add_column("Value", style="white bold")
+    table.add_row("Active DB", f"{active_db} ({scope})")
+    table.add_row("default_current_folder", str(default_local_value))
+
+    console = Console()
+    console.print(table)

--- a/clir/cli.py
+++ b/clir/cli.py
@@ -43,10 +43,13 @@ def _setup_db(use_local: bool, use_global: bool) -> None:
 
 
 def _find_git_root() -> Path:
+    home = Path.home()
     current = Path.cwd()
     while True:
         if (current / ".git").exists():
             return current
+        if current == home:
+            break
         parent = current.parent
         if parent == current:
             break

--- a/clir/config/clir.conf
+++ b/clir/config/clir.conf
@@ -1,7 +1,7 @@
 {
   "settings": [
     {
-      "name": "dafault_current_folder",
+      "name": "default_current_folder",
       "value": false,
       "description": "Always use current folder as default",
       "info": "If true, clir will get/save/delete/run commands from the folder where it was executed. For this to work you need to create a local project by adding the first command using the --local/-l flag."

--- a/clir/config/db/schema.sql
+++ b/clir/config/db/schema.sql
@@ -2,7 +2,7 @@ PRAGMA user_version = 1;
 CREATE TABLE IF NOT EXISTS commands (
     id TEXT PRIMARY KEY,
     creation_date TEXT NOT NULL,
-    last_modif_date TEST NOT NULL,
+    last_modif_date TEXT NOT NULL,
     command TEXT NOT NULL,
     description TEXT NOT NULL
 );

--- a/clir/utils/config.py
+++ b/clir/utils/config.py
@@ -1,10 +1,10 @@
 import importlib.resources
+import json
 import shutil
 from pathlib import Path
 
 from clir.utils.core import get_commands
-from clir.utils.db import create_database
-from clir.utils.db import insert_command_db
+from clir.utils.db import create_database, create_local_database, find_local_db, insert_command_db, set_active_db
 
 config_directory = "clir/config/"
 
@@ -118,3 +118,59 @@ def verify_clipboard_tool_installation(package: str = ""):
         return shutil.which(package) is not None
 
     return False
+
+
+def read_setting(name: str):
+    config_path = _config_file_path()
+    if not config_path.exists():
+        return None
+    with open(config_path) as f:
+        config = json.load(f)
+    for setting in config.get("settings", []):
+        if setting["name"] == name:
+            return setting["value"]
+    return None
+
+
+def write_setting(name: str, value) -> bool:
+    config_path = _config_file_path()
+    if not config_path.exists():
+        return False
+    with open(config_path) as f:
+        config = json.load(f)
+    for setting in config.get("settings", []):
+        if setting["name"] == name:
+            setting["value"] = value
+            with open(config_path, "w") as f:
+                json.dump(config, f, indent=2)
+            return True
+    return False
+
+
+def init_local_config(directory: Path = None) -> Path:
+    if directory is None:
+        directory = Path.cwd()
+    return create_local_database(directory)
+
+
+def configure_active_db(local: bool = False, use_global: bool = False) -> None:
+    set_active_db(None)  # reset to global each invocation
+
+    if use_global:
+        return
+
+    if local:
+        db_path = find_local_db()
+        if db_path is None:
+            raise ValueError(
+                "No local clir project found. Run 'clir init' in your project directory first."
+            )
+        set_active_db(db_path)
+        print(f"[local: {db_path.parent}]")
+        return
+
+    if read_setting("default_current_folder"):
+        db_path = find_local_db()
+        if db_path:
+            set_active_db(db_path)
+            print(f"[local: {db_path.parent}]")

--- a/clir/utils/config.py
+++ b/clir/utils/config.py
@@ -90,6 +90,22 @@ def copy_config_files():
 
         print(f"Copying {file_name} file to {dir_path}")
 
+def _migrate_config_settings():
+    config_path = _config_file_path()
+    if not config_path.exists():
+        return
+    with open(config_path) as f:
+        config = json.load(f)
+    changed = False
+    for setting in config.get("settings", []):
+        if setting.get("name") == "dafault_current_folder":
+            setting["name"] = "default_current_folder"
+            changed = True
+    if changed:
+        with open(config_path, "w") as f:
+            json.dump(config, f, indent=2)
+
+
 def init_config():
     if not check_config():
         dir_path = _env_path()
@@ -107,10 +123,12 @@ def init_config():
         copy_config_files()
 
         migrate_json_to_sqlite()
-    
+
     if not check_config():
         print("Could not set the initial configuration Up.")
         return
+
+    _migrate_config_settings()
     
 
 def verify_clipboard_tool_installation(package: str = ""):

--- a/clir/utils/db.py
+++ b/clir/utils/db.py
@@ -25,6 +25,41 @@ def _default_db_file() -> Path:
 db_file = None
 
 
+def set_active_db(path) -> None:
+    global db_file
+    db_file = path
+
+
+def get_active_db_path() -> Path:
+    return db_file or _default_db_file()
+
+
+def find_local_db() -> Path:
+    home = Path.home()
+    current = Path.cwd()
+    while True:
+        candidate = current / ".clir" / db_file_name
+        if candidate.exists():
+            return candidate
+        if current == home:
+            break
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return None
+
+
+def create_local_database(directory: Path = None) -> Path:
+    if directory is None:
+        directory = Path.cwd()
+    local_clir_dir = directory / ".clir"
+    local_clir_dir.mkdir(parents=True, exist_ok=True)
+    db_path = local_clir_dir / db_file_name
+    create_database(database_name=db_path)
+    return db_path
+
+
 def _timestamp_now() -> str:
     return datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
 

--- a/tests/15-local_project_db.py
+++ b/tests/15-local_project_db.py
@@ -2,11 +2,22 @@ import os
 import tempfile
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from clir.cli import init, ls, new, settings
 from clir.utils.config import configure_active_db, read_setting, write_setting
 from clir.utils.db import find_local_db, get_active_db_path, set_active_db
+
+
+@pytest.fixture(autouse=True)
+def reset_global_state():
+    """Reset db_file and default_current_folder before every test."""
+    set_active_db(None)
+    write_setting("default_current_folder", False)
+    yield
+    set_active_db(None)
+    write_setting("default_current_folder", False)
 
 
 # --- helpers ---
@@ -145,13 +156,10 @@ def test_configure_active_db_use_global_ignores_local():
 # --- settings ---
 
 def test_settings_read_write():
-    original = read_setting("default_current_folder")
     write_setting("default_current_folder", True)
     assert read_setting("default_current_folder") is True
     write_setting("default_current_folder", False)
     assert read_setting("default_current_folder") is False
-    if original is not None:
-        write_setting("default_current_folder", original)
 
 
 def test_settings_command_shows_active_db():
@@ -166,8 +174,6 @@ def test_settings_command_enables_default_local():
     result = runner.invoke(settings, ['--default-local'])
     assert result.exit_code == 0, result.output
     assert read_setting("default_current_folder") is True
-    # restore
-    write_setting("default_current_folder", False)
 
 
 def test_settings_command_disables_default_local():
@@ -192,8 +198,6 @@ def test_auto_local_when_default_current_folder_enabled():
         configure_active_db()
         assert get_active_db_path() == Path(project_dir) / ".clir" / "clir.db"
     finally:
-        write_setting("default_current_folder", False)
-        set_active_db(None)
         os.chdir(original_dir)
 
 

--- a/tests/15-local_project_db.py
+++ b/tests/15-local_project_db.py
@@ -1,0 +1,212 @@
+import os
+import tempfile
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from clir.cli import init, ls, new, settings
+from clir.utils.config import configure_active_db, read_setting, write_setting
+from clir.utils.db import find_local_db, get_active_db_path, set_active_db
+
+
+# --- helpers ---
+
+def _make_project_dir():
+    return tempfile.mkdtemp(prefix="clir-local-test-")
+
+
+# --- clir init ---
+
+def test_init_creates_local_db():
+    project_dir = _make_project_dir()
+    original_dir = os.getcwd()
+    os.chdir(project_dir)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(init)
+        assert result.exit_code == 0, result.output
+        assert (Path(project_dir) / ".clir" / "clir.db").exists()
+        assert "initialized" in result.output
+    finally:
+        os.chdir(original_dir)
+
+
+def test_init_already_initialized_is_idempotent():
+    project_dir = _make_project_dir()
+    original_dir = os.getcwd()
+    os.chdir(project_dir)
+    try:
+        runner = CliRunner()
+        runner.invoke(init)
+        result = runner.invoke(init)
+        assert result.exit_code == 0, result.output
+        assert "already initialized" in result.output
+    finally:
+        os.chdir(original_dir)
+
+
+# --- find_local_db ---
+
+def test_find_local_db_returns_path_when_present():
+    project_dir = _make_project_dir()
+    original_dir = os.getcwd()
+    os.chdir(project_dir)
+    try:
+        runner = CliRunner()
+        runner.invoke(init)
+        db_path = find_local_db()
+        assert db_path is not None
+        assert db_path == Path(project_dir) / ".clir" / "clir.db"
+    finally:
+        os.chdir(original_dir)
+
+
+def test_find_local_db_returns_none_when_absent():
+    project_dir = _make_project_dir()
+    original_dir = os.getcwd()
+    os.chdir(project_dir)
+    try:
+        assert find_local_db() is None
+    finally:
+        os.chdir(original_dir)
+
+
+# --- -l / --local flag ---
+
+def test_local_flag_errors_without_init():
+    project_dir = _make_project_dir()
+    original_dir = os.getcwd()
+    os.chdir(project_dir)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(ls, ['-l'])
+        assert result.exit_code != 0
+        assert "clir init" in result.output
+    finally:
+        os.chdir(original_dir)
+
+
+def test_local_flag_uses_local_db():
+    project_dir = _make_project_dir()
+    original_dir = os.getcwd()
+    os.chdir(project_dir)
+    try:
+        runner = CliRunner()
+        runner.invoke(init)
+        result = runner.invoke(new, ['-c', 'local-cmd', '-d', 'local desc', '-t', 'local-tag', '-l'])
+        assert result.exit_code == 0, result.output
+        assert "[local:" in result.output
+
+        ls_result = runner.invoke(ls, ['-l'])
+        assert ls_result.exit_code == 0, ls_result.output
+        assert "local-cmd" in ls_result.output
+    finally:
+        os.chdir(original_dir)
+
+
+def test_global_flag_uses_global_db():
+    """Commands saved with -l should not appear when using -G."""
+    project_dir = _make_project_dir()
+    original_dir = os.getcwd()
+    os.chdir(project_dir)
+    try:
+        runner = CliRunner()
+        runner.invoke(init)
+        runner.invoke(new, ['-c', 'local-only-cmd', '-d', 'desc', '-t', 'test', '-l'])
+
+        ls_result = runner.invoke(ls, ['-G'])
+        assert ls_result.exit_code == 0, ls_result.output
+        assert "local-only-cmd" not in ls_result.output
+    finally:
+        os.chdir(original_dir)
+
+
+# --- configure_active_db ---
+
+def test_configure_active_db_resets_to_global():
+    set_active_db(Path("/some/fake/path"))
+    configure_active_db(local=False, use_global=False)
+    assert get_active_db_path() == Path.home() / ".clir" / "clir.db"
+
+
+def test_configure_active_db_use_global_ignores_local():
+    project_dir = _make_project_dir()
+    original_dir = os.getcwd()
+    os.chdir(project_dir)
+    try:
+        runner = CliRunner()
+        runner.invoke(init)
+        configure_active_db(local=False, use_global=True)
+        assert get_active_db_path() == Path.home() / ".clir" / "clir.db"
+    finally:
+        os.chdir(original_dir)
+
+
+# --- settings ---
+
+def test_settings_read_write():
+    original = read_setting("default_current_folder")
+    write_setting("default_current_folder", True)
+    assert read_setting("default_current_folder") is True
+    write_setting("default_current_folder", False)
+    assert read_setting("default_current_folder") is False
+    if original is not None:
+        write_setting("default_current_folder", original)
+
+
+def test_settings_command_shows_active_db():
+    runner = CliRunner()
+    result = runner.invoke(settings)
+    assert result.exit_code == 0, result.output
+    assert "clir.db" in result.output
+
+
+def test_settings_command_enables_default_local():
+    runner = CliRunner()
+    result = runner.invoke(settings, ['--default-local'])
+    assert result.exit_code == 0, result.output
+    assert read_setting("default_current_folder") is True
+    # restore
+    write_setting("default_current_folder", False)
+
+
+def test_settings_command_disables_default_local():
+    write_setting("default_current_folder", True)
+    runner = CliRunner()
+    result = runner.invoke(settings, ['--no-default-local'])
+    assert result.exit_code == 0, result.output
+    assert read_setting("default_current_folder") is False
+
+
+# --- default_current_folder auto-detection ---
+
+def test_auto_local_when_default_current_folder_enabled():
+    project_dir = _make_project_dir()
+    original_dir = os.getcwd()
+    os.chdir(project_dir)
+    try:
+        runner = CliRunner()
+        runner.invoke(init)
+        write_setting("default_current_folder", True)
+
+        configure_active_db()
+        assert get_active_db_path() == Path(project_dir) / ".clir" / "clir.db"
+    finally:
+        write_setting("default_current_folder", False)
+        set_active_db(None)
+        os.chdir(original_dir)
+
+
+def test_no_auto_local_when_default_current_folder_disabled():
+    project_dir = _make_project_dir()
+    original_dir = os.getcwd()
+    os.chdir(project_dir)
+    try:
+        runner = CliRunner()
+        runner.invoke(init)
+        write_setting("default_current_folder", False)
+
+        configure_active_db()
+        assert get_active_db_path() == Path.home() / ".clir" / "clir.db"
+    finally:
+        os.chdir(original_dir)


### PR DESCRIPTION
## Summary

- Adds `clir init` to create a local `.clir/clir.db` in the current project directory (global DB auto-init on first run is unchanged)
- Adds `-l/--local` and `-G/--global` flags to all 8 commands to control which DB is used
- Implements `clir settings` with `--default-local/--no-default-local` to auto-switch to local DB when present
- Adds `_migrate_config_settings()` to fix the `dafault_current_folder` typo in existing `clir.conf` files on upgrade
- Fixes pre-existing `schema.sql` typo: `TEST` → `TEXT`
- 13 new tests in `tests/15-local_project_db.py`

## DB scope resolution priority
1. `-l/--local` → use local DB (error if not initialized)
2. `-G/--global` → force global DB
3. `default_current_folder = true` + local DB found → auto-use local DB
4. Default → global DB (`~/.clir/clir.db`)

## Test plan
- [ ] `clir init` creates `.clir/clir.db` in CWD
- [ ] `clir init` in a git repo offers to update `.gitignore`
- [ ] `clir new -l` / `clir ls -l` use the local DB
- [ ] `clir ls -G` ignores local DB even when present
- [ ] `clir ls -l` without prior `clir init` exits with actionable error
- [ ] `clir settings --default-local` enables auto-detection
- [ ] Existing commands without flags behave identically to before
- [ ] Run full ordered test suite: `pytest -v -s tests/1-init_clir.py tests/2-add_command.py tests/3-copy_command.py tests/4-run_command.py tests/5-remove_command.py tests/6-list_command.py tests/7-import_export_command.py tests/15-local_project_db.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)