### PR TITLE
Repair invalid config files during init

### DIFF
--- a/clir/utils/config.py
+++ b/clir/utils/config.py
@@ -24,6 +24,42 @@ def _config_file_path() -> Path:
 def _db_file_path() -> Path:
     return _env_path() / "clir.db"
 
+
+def _default_config() -> dict:
+    with importlib.resources.open_text('clir.config', 'clir.conf') as f:
+        return json.load(f)
+
+
+def _backup_invalid_config(config_path: Path) -> None:
+    backup_path = config_path.with_suffix(f"{config_path.suffix}.backup")
+    shutil.copyfile(config_path, backup_path)
+    print(f"Invalid config backed up to {backup_path}")
+
+
+def _repair_config_file(config_path: Path) -> dict:
+    if config_path.exists():
+        _backup_invalid_config(config_path)
+
+    config = _default_config()
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+
+    print(f"Recreated config file at {config_path}")
+    return config
+
+
+def _load_config(config_path: Path, repair: bool = False):
+    if not config_path.exists():
+        return None
+
+    try:
+        with open(config_path) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        if not repair:
+            return None
+        return _repair_config_file(config_path)
+
 def check_config():
     return _db_file_path().exists() and _config_file_path().exists()
 
@@ -92,10 +128,10 @@ def copy_config_files():
 
 def _migrate_config_settings():
     config_path = _config_file_path()
-    if not config_path.exists():
+    config = _load_config(config_path, repair=True)
+    if config is None:
         return
-    with open(config_path) as f:
-        config = json.load(f)
+
     changed = False
     for setting in config.get("settings", []):
         if setting.get("name") == "dafault_current_folder":
@@ -140,10 +176,10 @@ def verify_clipboard_tool_installation(package: str = ""):
 
 def read_setting(name: str):
     config_path = _config_file_path()
-    if not config_path.exists():
+    config = _load_config(config_path, repair=True)
+    if config is None:
         return None
-    with open(config_path) as f:
-        config = json.load(f)
+
     for setting in config.get("settings", []):
         if setting["name"] == name:
             return setting["value"]
@@ -152,10 +188,10 @@ def read_setting(name: str):
 
 def write_setting(name: str, value) -> bool:
     config_path = _config_file_path()
-    if not config_path.exists():
+    config = _load_config(config_path, repair=True)
+    if config is None:
         return False
-    with open(config_path) as f:
-        config = json.load(f)
+
     for setting in config.get("settings", []):
         if setting["name"] == name:
             setting["value"] = value

--- a/tests/12-config_utils.py
+++ b/tests/12-config_utils.py
@@ -61,6 +61,35 @@ def test_init_config_returns_when_setup_cannot_be_completed(monkeypatch):
     ]
 
 
+def test_init_config_repairs_empty_config_file(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    clir_dir = tmp_path / ".clir"
+    clir_dir.mkdir(parents=True)
+    (clir_dir / "clir.db").write_text("db", encoding="utf-8")
+    (clir_dir / "clir.conf").write_text("", encoding="utf-8")
+
+    config_module.init_config()
+
+    repaired_config = (clir_dir / "clir.conf").read_text(encoding="utf-8")
+    backup_file = clir_dir / "clir.conf.backup"
+
+    assert 'default_current_folder' in repaired_config
+    assert backup_file.exists()
+    assert backup_file.read_text(encoding="utf-8") == ""
+
+
+def test_read_setting_repairs_invalid_config_file(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    clir_dir = tmp_path / ".clir"
+    clir_dir.mkdir(parents=True)
+    (clir_dir / "clir.conf").write_text("not-json", encoding="utf-8")
+
+    value = config_module.read_setting("default_current_folder")
+
+    assert value is False
+    assert (clir_dir / "clir.conf.backup").exists()
+
+
 def test_verify_clipboard_tool_installation_xclip_true(monkeypatch):
     monkeypatch.setattr(config_module.shutil, "which", lambda package: f"/usr/bin/{package}")
 


### PR DESCRIPTION
## Summary
- repair empty or invalid `~/.clir/clir.conf` files by backing them up and recreating the default config instead of crashing during startup
- reuse the same repair path in config reads and writes so corrupted local config state does not break normal CLI commands
- add regression tests for empty and invalid config repair behavior

## Validation
- poetry run pytest -v -s tests/12-config_utils.py tests/15-local_project_db.py::test_local_flag_errors_without_init